### PR TITLE
Fix photo path handling and dark mode table

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,7 +35,7 @@ app.set('views', path.join(__dirname, 'views'));
 // Middleware pour le corps des requêtes et les fichiers statiques
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(express.static(path.join(__dirname, 'public')));
-app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
+app.use('/uploads', express.static(path.join(__dirname, 'uploads'), { maxAge: 0 }));
 
 // Sessions et messages flash
 app.use(session({

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -22,7 +22,11 @@
   }
 
 body.mode-sombre table {
-    background-color: #000000;
+    background-color: #1f1f1f !important;
+  }
+
+body.mode-sombre thead th {
+    background-color: #2c2c2c !important;
   }
 
   body.mode-sombre th,

--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -210,7 +210,7 @@
               </td>
                 <td>
                 <% if (mc.materiel.photos && mc.materiel.photos.length > 0) { %>
-                  <img src="/<%= mc.materiel.photos[0].chemin.replace(/\\\\/g, '/') %>" alt="Photo"
+                  <img src="/<%= mc.materiel.photos[0].chemin.replace(/\\/g, '/') %>" alt="Photo"
                       width="80" style="cursor: pointer;"
                       data-bs-toggle="modal" data-bs-target="#photoModal<%= mc.id %>">
 
@@ -223,7 +223,7 @@
                           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
                         </div>
                         <div class="modal-body text-center">
-                          <img src="/<%= mc.materiel.photos[0].chemin.replace(/\\\\/g, '/') %>" alt="Photo grand format" class="img-fluid rounded">
+                          <img src="/<%= mc.materiel.photos[0].chemin.replace(/\\/g, '/') %>" alt="Photo grand format" class="img-fluid rounded">
                         </div>
                       </div>
                     </div>

--- a/views/chantier/infoMaterielChantier.ejs
+++ b/views/chantier/infoMaterielChantier.ejs
@@ -44,7 +44,7 @@
 
         <% if (mc.materiel.photos && mc.materiel.photos.length > 0) { %>
           <p><strong>🖼️ Photo :</strong></p>
-          <img src="/<%= mc.materiel.photos[0].chemin.replace(/\\\\/g, '/') %>" alt="Photo du matériel">
+          <img src="/<%= mc.materiel.photos[0].chemin.replace(/\\/g, '/') %>" alt="Photo du matériel">
         <% } else { %>
           <p><strong>🖼️ Photo :</strong> -</p>
         <% } %>

--- a/views/chantier/modifierMaterielChantier.ejs
+++ b/views/chantier/modifierMaterielChantier.ejs
@@ -83,7 +83,7 @@
       <div id="preview-container" class="mt-3">
         <% if (mc.materiel.photos && mc.materiel.photos.length > 0) { %>
           <p>Photo actuelle :</p>
-          <img src="/<%= mc.materiel.photos[0].chemin.replace(/\\\\/g, '/') %>" alt="Photo actuelle" style="max-width: 300px; border: 1px solid #ccc;">
+          <img src="/<%= mc.materiel.photos[0].chemin.replace(/\\/g, '/') %>" alt="Photo actuelle" style="max-width: 300px; border: 1px solid #ccc;">
         <% } %>
         
         <!--<p class="mt-2">Aperçu de la nouvelle photo :</p>-->

--- a/views/materiel/dashboard.ejs
+++ b/views/materiel/dashboard.ejs
@@ -310,8 +310,8 @@
                   <td>
                     <% if (m.photos && m.photos.length > 0) { %>
                       <% m.photos.forEach(function(photo) { %>
-                        <a href="/<%= photo.chemin.replace(/\\\\/g, '/') %>" target="_blank" class="me-1">
-                          <img src="/<%= photo.chemin.replace(/\\\\/g, '/') %>" alt="Photo" style="width: 50px; height: auto;">
+                          <a href="/<%= photo.chemin.replace(/\\/g, '/') %>" target="_blank" class="me-1">
+                          <img src="/<%= photo.chemin.replace(/\\/g, '/') %>" alt="Photo" style="width: 50px; height: auto;">
                         </a>
                       <% }) %>
                     <% } else { %>
@@ -357,7 +357,7 @@
             <strong>Photos :</strong>
             <% if (m.photos.length) { %>
               <% m.photos.forEach(photo => { %>
-                <a href="/<%= photo.chemin.replace(/\\\\/g, '/') %>" target="_blank">📷</a>
+                  <a href="/<%= photo.chemin.replace(/\\/g, '/') %>" target="_blank">📷</a>
               <% }) %>
             <% } else { %>Aucune<% } %>
           </li>


### PR DESCRIPTION
## Summary
- serve uploaded images without caching
- fix image path generation to handle backslashes
- improve table colors in dark mode

## Testing
- `npm run --silent start` *(fails: Please install sqlite3 package manually)*

------
https://chatgpt.com/codex/tasks/task_e_68551e3e09fc832797d178645c9046e2