### PR TITLE
Adjust table colors in dark mode

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -9,6 +9,7 @@
     --bg-color: #1a1a1a;
     --text-color: #e0e0e0;
     --primary-color: #bb86fc;
+    --bs-table-bg: #383838;
   }
   
   body {
@@ -22,7 +23,7 @@
   }
 
 body.mode-sombre table {
-    background-color: #1f1f1f !important;
+    background-color: var(--bs-table-bg) !important;
   }
 
 body.mode-sombre thead th {

--- a/views/materiel/dashboard.ejs
+++ b/views/materiel/dashboard.ejs
@@ -77,7 +77,7 @@
     /* =================== TABLEAU EN MODE SOMBRE =================== */
     body.mode-sombre table.table-bordered {
       border-color: #444;
-      background-color: #000;
+      background-color: var(--bs-table-bg);
     }
     body.mode-sombre .table thead th {
       background-color: #2c2c2c;


### PR DESCRIPTION
## Summary
- add `--bs-table-bg` variable for dark theme
- use the new var for table backgrounds
- update material dashboard dark mode table

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685520598f6483278338fe2411c7a9dc