### PR TITLE
Remove table background var for dark mode

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -9,7 +9,6 @@
     --bg-color: #1a1a1a;
     --text-color: #e0e0e0;
     --primary-color: #bb86fc;
-    --bs-table-bg: #383838;
   }
   
   body {
@@ -22,9 +21,6 @@
     border-color: var(--primary-color);
   }
 
-body.mode-sombre table {
-    background-color: var(--bs-table-bg) !important;
-  }
 
 body.mode-sombre thead th {
     background-color: #2c2c2c !important;


### PR DESCRIPTION
## Summary
- clean up dark mode table style so bootstrap defaults apply

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685522cff54c8327a2cdd45d9fee4941