### PR TITLE
Fix dark mode table text color

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -28,7 +28,7 @@ body.mode-sombre thead th {
 
   body.mode-sombre th,
   body.mode-sombre td {
-    color: #ffffff;
+    color: #000000;
   }
   
   /* Ajoute d'autres styles personnalisés ici si nécessaire */

--- a/views/chantier/historique.ejs
+++ b/views/chantier/historique.ejs
@@ -85,6 +85,7 @@
     body.mode-sombre .card-header,
     body.mode-sombre .table-historique thead th {
       background-color: #2d3436 !important; /* gris très foncé */
+      color: #000;
     }
     body.mode-sombre .table-historique tbody tr:hover {
       background-color: #3a3a3a;

--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -20,7 +20,7 @@
     }
     body.mode-sombre .table thead th {
       background-color: #2c2c2c;
-      color: #fff;
+      color: #000;
     }
     body.mode-sombre .table-striped > tbody > tr:nth-of-type(odd) {
       --bs-table-accent-bg: #2a2a2a;

--- a/views/materiel/dashboard.ejs
+++ b/views/materiel/dashboard.ejs
@@ -81,7 +81,7 @@
     }
     body.mode-sombre .table thead th {
       background-color: #2c2c2c;
-      color: #fff;
+      color: #000;
     }
     body.mode-sombre .table-striped > tbody > tr:nth-of-type(odd) {
       --bs-table-accent-bg: #2a2a2a;

--- a/views/materiel/historique.ejs
+++ b/views/materiel/historique.ejs
@@ -85,6 +85,7 @@
     body.mode-sombre .card-header,
     body.mode-sombre .table-historique thead th {
       background-color: #2d3436 !important; /* gris très foncé */
+      color: #000;
     }
     body.mode-sombre .table-historique tbody tr:hover {
       background-color: #3a3a3a;

--- a/views/vehicule/historique.ejs
+++ b/views/vehicule/historique.ejs
@@ -89,6 +89,7 @@
     body.mode-sombre .card-header,
     body.mode-sombre .table-historique thead th {
       background-color: #2d3436 !important; /* un gris très foncé */
+      color: #000;
     }
     body.mode-sombre .table-historique tbody tr:hover {
       background-color: #3a3a3a;


### PR DESCRIPTION
## Summary
- tweak global dark mode table text color
- update dark mode table header color on chantier dashboard
- update dark mode table header color on materiel dashboard
- add dark mode header color on vehicule, materiel and chantier history pages

## Testing
- `npm test` *(fails: Missing script and no network access)*

------
https://chatgpt.com/codex/tasks/task_e_685523fc42d08327997a21bf05685a47