### PR TITLE
Fix dark mode header colors

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -24,11 +24,12 @@
 
 body.mode-sombre thead th {
     background-color: #2c2c2c !important;
+    color: #ffffff;
   }
 
   body.mode-sombre th,
   body.mode-sombre td {
-    color: #000000;
+    color: var(--text-color);
   }
   
   /* Ajoute d'autres styles personnalisés ici si nécessaire */

--- a/views/chantier/historique.ejs
+++ b/views/chantier/historique.ejs
@@ -85,7 +85,7 @@
     body.mode-sombre .card-header,
     body.mode-sombre .table-historique thead th {
       background-color: #2d3436 !important; /* gris très foncé */
-      color: #000;
+      color: #fff;
     }
     body.mode-sombre .table-historique tbody tr:hover {
       background-color: #3a3a3a;

--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -20,7 +20,7 @@
     }
     body.mode-sombre .table thead th {
       background-color: #2c2c2c;
-      color: #000;
+      color: #fff;
     }
     body.mode-sombre .table-striped > tbody > tr:nth-of-type(odd) {
       --bs-table-accent-bg: #2a2a2a;

--- a/views/materiel/dashboard.ejs
+++ b/views/materiel/dashboard.ejs
@@ -81,7 +81,7 @@
     }
     body.mode-sombre .table thead th {
       background-color: #2c2c2c;
-      color: #000;
+      color: #fff;
     }
     body.mode-sombre .table-striped > tbody > tr:nth-of-type(odd) {
       --bs-table-accent-bg: #2a2a2a;

--- a/views/materiel/historique.ejs
+++ b/views/materiel/historique.ejs
@@ -85,7 +85,7 @@
     body.mode-sombre .card-header,
     body.mode-sombre .table-historique thead th {
       background-color: #2d3436 !important; /* gris très foncé */
-      color: #000;
+      color: #fff;
     }
     body.mode-sombre .table-historique tbody tr:hover {
       background-color: #3a3a3a;

--- a/views/vehicule/historique.ejs
+++ b/views/vehicule/historique.ejs
@@ -89,7 +89,7 @@
     body.mode-sombre .card-header,
     body.mode-sombre .table-historique thead th {
       background-color: #2d3436 !important; /* un gris très foncé */
-      color: #000;
+      color: #fff;
     }
     body.mode-sombre .table-historique tbody tr:hover {
       background-color: #3a3a3a;


### PR DESCRIPTION
## Summary
- keep dark mode headers readable
- update stock views to use white text for table headers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855299a36f08327a6b8221fce8bdf53