### PR TITLE
Ensure white headers in dark mode

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -24,7 +24,12 @@
 /* Couleur du texte pour les informations de matériel */
 .table-materiel th,
 .table-materiel td {
-  color: #000 !important;
+  color: #000;
+}
+
+body.mode-sombre .table-materiel th,
+body.mode-sombre .table-materiel td {
+  color: #fff;
 }
 
 


### PR DESCRIPTION
## Summary
- fix `.table-materiel` styles so headers turn white when dark mode is enabled

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855338755088327952dd1d1090fa4a3