### PR TITLE
Store images in DB

### DIFF
--- a/models/Photo.js
+++ b/models/Photo.js
@@ -11,10 +11,16 @@ const Photo = sequelize.define(
       autoIncrement: true,
     },
 
-    // Chemin ou URL vers le fichier image
+    // Chemin vers le fichier image (optionnel si stockage en BDD)
     chemin: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
+    },
+
+    // Données binaires de la photo pour un stockage persistant
+    data: {
+      type: DataTypes.BLOB('long'),
+      allowNull: true,
     },
 
     // FK vers le matériel associé

--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -5,6 +5,7 @@ const router = express.Router();
 const { Op } = require('sequelize');
 const multer = require('multer');
 const path = require('path');
+const fs = require('fs');
 
 const Materiel = require('../models/Materiel');
 const Photo = require('../models/Photo');
@@ -168,8 +169,10 @@ router.post('/ajouterMateriel', ensureAuthenticated, checkAdmin, upload.array('p
         const relativePath = path
           .join('uploads', file.filename)
           .replace(/\\/g, '/');
+        const data = fs.readFileSync(file.path);
         await Photo.create({
           chemin: relativePath,
+          data,
           materielId: nouveauMateriel.id
         });
       }
@@ -458,8 +461,10 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
       const chemin = path
         .join('uploads', req.file.filename)
         .replace(/\\/g, '/');
+      const data = fs.readFileSync(req.file.path);
       await Photo.create({
         chemin,
+        data,
         materielId: mc.materiel.id
       });
     }
@@ -536,8 +541,10 @@ router.post('/materielChantier/dupliquer/:id', ensureAuthenticated, checkAdmin, 
       const chemin = path
         .join('uploads', req.file.filename)
         .replace(/\\/g, '/');
+      const data = fs.readFileSync(req.file.path);
       await Photo.create({
         chemin,
+        data,
         materielId: nouveauMateriel.id
       });
     }

--- a/routes/materiel.js
+++ b/routes/materiel.js
@@ -3,6 +3,7 @@ const express = require('express');
 const router = express.Router();
 const multer = require('multer');
 const path = require('path');
+const fs = require('fs');
 const { Op } = require('sequelize');
 const ExcelJS = require('exceljs');
 const PDFDocument = require('pdfkit');
@@ -289,8 +290,10 @@ router.post('/ajouter', ensureAuthenticated, checkAdmin, upload.array('photos', 
         const relativePath = path
           .join('uploads', file.filename)
           .replace(/\\/g, '/');
+        const data = fs.readFileSync(file.path);
         await Photo.create({
           chemin: relativePath,
+          data,
           materielId: nouveauMateriel.id
         });
       }

--- a/routes/vehicule.js
+++ b/routes/vehicule.js
@@ -4,6 +4,7 @@ const router = express.Router();
 const { Op } = require('sequelize');
 const multer = require('multer');
 const path = require('path');
+const fs = require('fs');
 
 const Materiel = require('../models/Materiel');
 const Photo = require('../models/Photo');
@@ -115,8 +116,10 @@ router.post('/ajouter', ensureAuthenticated,checkAdmin, upload.array('photos', 5
         const relativePath = path
           .join('uploads', file.filename)
           .replace(/\\/g, '/');
+        const data = fs.readFileSync(file.path);
         await Photo.create({
           chemin: relativePath,
+          data,
           materielId: nouveauMateriel.id
         });
       }

--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -210,7 +210,11 @@
               </td>
                 <td>
                 <% if (mc.materiel.photos && mc.materiel.photos.length > 0) { %>
-                  <img src="/<%= mc.materiel.photos[0].chemin.replace(/\\/g, '/') %>" alt="Photo"
+                  <% const photo = mc.materiel.photos[0]; %>
+                  <% const src = photo.data ?
+                    ('data:image/jpeg;base64,' + photo.data.toString('base64')) :
+                    ('/' + photo.chemin.replace(/\\/g, '/')); %>
+                  <img src="<%= src %>" alt="Photo"
                       width="80" style="cursor: pointer;"
                       data-bs-toggle="modal" data-bs-target="#photoModal<%= mc.id %>">
 
@@ -223,7 +227,7 @@
                           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
                         </div>
                         <div class="modal-body text-center">
-                          <img src="/<%= mc.materiel.photos[0].chemin.replace(/\\/g, '/') %>" alt="Photo grand format" class="img-fluid rounded">
+                          <img src="<%= src %>" alt="Photo grand format" class="img-fluid rounded">
                         </div>
                       </div>
                     </div>

--- a/views/chantier/infoMaterielChantier.ejs
+++ b/views/chantier/infoMaterielChantier.ejs
@@ -43,11 +43,15 @@
         <p><strong>📐 Niveau :</strong> <%= mc.materiel.niveau || '-' %></p>
 
         <% if (mc.materiel.photos && mc.materiel.photos.length > 0) { %>
-          <p><strong>🖼️ Photo :</strong></p>
-          <img src="/<%= mc.materiel.photos[0].chemin.replace(/\\/g, '/') %>" alt="Photo du matériel">
-        <% } else { %>
-          <p><strong>🖼️ Photo :</strong> -</p>
-        <% } %>
+            <p><strong>🖼️ Photo :</strong></p>
+            <% const photo = mc.materiel.photos[0]; %>
+            <% const src = photo.data ?
+              ('data:image/jpeg;base64,' + photo.data.toString('base64')) :
+              ('/' + photo.chemin.replace(/\\/g, '/')); %>
+            <img src="<%= src %>" alt="Photo du matériel">
+          <% } else { %>
+            <p><strong>🖼️ Photo :</strong> -</p>
+          <% } %>
       </div>
     </div>
 

--- a/views/chantier/modifierMaterielChantier.ejs
+++ b/views/chantier/modifierMaterielChantier.ejs
@@ -83,7 +83,11 @@
       <div id="preview-container" class="mt-3">
         <% if (mc.materiel.photos && mc.materiel.photos.length > 0) { %>
           <p>Photo actuelle :</p>
-          <img src="/<%= mc.materiel.photos[0].chemin.replace(/\\/g, '/') %>" alt="Photo actuelle" style="max-width: 300px; border: 1px solid #ccc;">
+          <% const photo = mc.materiel.photos[0]; %>
+          <% const src = photo.data ?
+            ('data:image/jpeg;base64,' + photo.data.toString('base64')) :
+            ('/' + photo.chemin.replace(/\\/g, '/')); %>
+          <img src="<%= src %>" alt="Photo actuelle" style="max-width: 300px; border: 1px solid #ccc;">
         <% } %>
         
         <!--<p class="mt-2">Aperçu de la nouvelle photo :</p>-->

--- a/views/materiel/dashboard.ejs
+++ b/views/materiel/dashboard.ejs
@@ -308,15 +308,18 @@
                   <td><%= m.description %></td>
                   <td><%= m.prix %> €</td>
                   <td>
-                    <% if (m.photos && m.photos.length > 0) { %>
-                      <% m.photos.forEach(function(photo) { %>
-                          <a href="/<%= photo.chemin.replace(/\\/g, '/') %>" target="_blank" class="me-1">
-                          <img src="/<%= photo.chemin.replace(/\\/g, '/') %>" alt="Photo" style="width: 50px; height: auto;">
-                        </a>
-                      <% }) %>
-                    <% } else { %>
-                      <span class="text-muted">Aucune</span>
-                    <% } %>
+                      <% if (m.photos && m.photos.length > 0) { %>
+                        <% m.photos.forEach(function(photo) { %>
+                          <% const src = photo.data ?
+                            ('data:image/jpeg;base64,' + photo.data.toString('base64')) :
+                            ('/' + photo.chemin.replace(/\\/g, '/')); %>
+                          <a href="<%= src %>" target="_blank" class="me-1">
+                            <img src="<%= src %>" alt="Photo" style="width: 50px; height: auto;">
+                          </a>
+                        <% }) %>
+                      <% } else { %>
+                        <span class="text-muted">Aucune</span>
+                      <% } %>
                   </td>
                   <td>
                     <% if (user && user.role === 'admin') { %>
@@ -354,12 +357,15 @@
           <li><strong>Description :</strong> <%= m.description %></li>
           <li><strong>Prix :</strong> <%= m.prix %> €</li>
           <li>
-            <strong>Photos :</strong>
-            <% if (m.photos.length) { %>
-              <% m.photos.forEach(photo => { %>
-                  <a href="/<%= photo.chemin.replace(/\\/g, '/') %>" target="_blank">📷</a>
-              <% }) %>
-            <% } else { %>Aucune<% } %>
+              <strong>Photos :</strong>
+              <% if (m.photos.length) { %>
+                <% m.photos.forEach(photo => { %>
+                  <% const src = photo.data ?
+                    ('data:image/jpeg;base64,' + photo.data.toString('base64')) :
+                    ('/' + photo.chemin.replace(/\\/g, '/')); %>
+                  <a href="<%= src %>" target="_blank">📷</a>
+                <% }) %>
+              <% } else { %>Aucune<% } %>
           </li>
         </ul>
         <% if (user && user.role==='admin') { %>

--- a/views/vehicule/dashboard.ejs
+++ b/views/vehicule/dashboard.ejs
@@ -84,17 +84,20 @@
               </td>
               <td><%= m.description %></td>
               <td><%= m.prix %> €</td>
-              <td>
-                <% if (m.photos && m.photos.length > 0) { %>
-                  <% m.photos.forEach(function(photo) { %>
-                    <a href="/<%= photo.chemin %>" target="_blank">
-                      <img src="/<%= photo.chemin %>" alt="Photo" style="width: 50px; height: auto; margin-right: 5px;">
-                    </a>
-                  <% }); %>
-                <% } else { %>
-                  Aucun
-                <% } %>
-              </td>
+                <td>
+                  <% if (m.photos && m.photos.length > 0) { %>
+                    <% m.photos.forEach(function(photo) { %>
+                      <% const src = photo.data ?
+                        ('data:image/jpeg;base64,' + photo.data.toString('base64')) :
+                        ('/' + photo.chemin); %>
+                      <a href="<%= src %>" target="_blank">
+                        <img src="<%= src %>" alt="Photo" style="width: 50px; height: auto; margin-right: 5px;">
+                      </a>
+                    <% }); %>
+                  <% } else { %>
+                    Aucun
+                  <% } %>
+                </td>
               <td>
                 <!-- Boutons cliquables : pointer vers les routes /modifier/:id et /supprimer/:id -->
                 <a href="/vehicule/modifier/<%= m.id %>" class="btn btn-warning btn-sm">Modifier</a>


### PR DESCRIPTION
## Summary
- store photo binary data in DB
- handle in-memory images in display templates
- update upload routes to save photo data

## Testing
- `npm start` *(fails: Please install sqlite3 package manually)*

------
https://chatgpt.com/codex/tasks/task_e_6858feb7dc748327ad006eac574399c9