### PR TITLE
Add supplier and designation fields to chantier forms

### DIFF
--- a/models/Materiel.js
+++ b/models/Materiel.js
@@ -12,6 +12,7 @@ const Materiel = sequelize.define(
     description: { type: DataTypes.TEXT },
     prix: { type: DataTypes.DECIMAL(10, 2) },
     categorie: { type: DataTypes.STRING },
+    fournisseur: { type: DataTypes.STRING },
     rack: { type: DataTypes.STRING },
     compartiment: { type: DataTypes.STRING },
     niveau: { type: DataTypes.INTEGER },

--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -143,7 +143,7 @@ const emplacements = emplacementsBruts.map(e => ({
 
 router.post('/ajouterMateriel', ensureAuthenticated, checkAdmin, upload.array('photos', 5), async (req, res) => {
   try {
-    const { nom, reference, quantite, description, prix, categorie, chantierId, emplacementId, rack, compartiment, niveau } = req.body;
+    const { nom, reference, quantite, description, prix, categorie, fournisseur, chantierId, emplacementId, rack, compartiment, niveau } = req.body;
 
     
     // 1) Créer le matériel avec quantite=0 dans la table Materiel
@@ -154,6 +154,7 @@ router.post('/ajouterMateriel', ensureAuthenticated, checkAdmin, upload.array('p
   description,
   prix: parseFloat(prix),
   categorie,
+  fournisseur,
   vehiculeId: null,
   emplacementId: emplacementId ? parseInt(emplacementId) : null,
    rack,
@@ -392,7 +393,7 @@ router.get('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, as
 router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, upload.single('photo'), async (req, res) => {
   try {
     const {
-      quantite, nomMateriel, categorie, emplacementId,
+      quantite, nomMateriel, categorie, fournisseur, emplacementId,
       rack, compartiment, niveau
     } = req.body;
 
@@ -412,6 +413,7 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
     const oldEmplacement = mc.materiel.emplacementId;
     const oldRack = mc.materiel.rack;
     const oldCompartiment = mc.materiel.compartiment;
+    const oldFournisseur = mc.materiel.fournisseur;
     const oldNiveau = mc.materiel.niveau;
 
     const newQte = parseInt(quantite, 10);
@@ -420,6 +422,7 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
     const newEmplacement = emplacementId ? parseInt(emplacementId) : null;
     const newRack = rack;
     const newCompartiment = compartiment;
+    const newFournisseur = fournisseur;
     const newNiveau = niveau ? parseInt(niveau) : null;
 
     if (oldQte !== newQte) changementsDetail.push(`Quantité: ${oldQte} ➔ ${newQte}`);
@@ -427,6 +430,7 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
     if (oldCategorie !== newCategorie) changementsDetail.push(`Catégorie: ${oldCategorie || '-'} ➔ ${newCategorie}`);
     if (oldEmplacement !== newEmplacement) changementsDetail.push(`Emplacement: ${oldEmplacement || '-'} ➔ ${newEmplacement || '-'}`);
     if (oldRack !== newRack) changementsDetail.push(`Rack: ${oldRack || '-'} ➔ ${newRack || '-'}`);
+    if (oldFournisseur !== newFournisseur) changementsDetail.push(`Fournisseur: ${oldFournisseur || '-'} ➔ ${newFournisseur || '-'}`);
     if (oldCompartiment !== newCompartiment) changementsDetail.push(`Compartiment: ${oldCompartiment || '-'} ➔ ${newCompartiment || '-'}`);
     if (oldNiveau !== newNiveau) changementsDetail.push(`Niveau: ${oldNiveau || '-'} ➔ ${newNiveau || '-'}`);
 
@@ -435,6 +439,7 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
     mc.materiel.nom = newNom;
     mc.materiel.categorie = newCategorie;
     mc.materiel.emplacementId = newEmplacement;
+    mc.materiel.fournisseur = newFournisseur;
     mc.materiel.rack = newRack;
     mc.materiel.compartiment = newCompartiment;
     mc.materiel.niveau = newNiveau;

--- a/views/chantier/ajouterMateriel.ejs
+++ b/views/chantier/ajouterMateriel.ejs
@@ -166,8 +166,125 @@ select#emplacementId.form-control {
     <h2>Ajouter du Matériel dans un Chantier</h2>
     <form action="/chantier/ajouterMateriel" method="POST" enctype="multipart/form-data">
       <div class="mb-3">
-        <label for="nom" class="form-label">Nom du Matériel</label>
-        <input type="text" name="nom" id="nom" class="form-control" required>
+        <label for="nom" class="form-label">Désignation</label>
+        <input type="text" name="nom" id="nom" class="form-control">
+        <select id="designationSelect" class="form-select mt-2">
+          <option value="">-- Sélectionner une désignation --</option>
+          <option value="PROFIL NR LAZER L-R 2,01M">PROFIL NR LAZER L-R 2,01M</option>
+          <option value="2 Conteneurs + 1 Algeco + Benne DIB & Bois">2 Conteneurs + 1 Algeco + Benne DIB & Bois</option>
+          <option value="ALIM 15W IP20 24VDC">ALIM 15W IP20 24VDC</option>
+          <option value="AUSTRALE DIAM 125">AUSTRALE DIAM 125</option>
+          <option value="Applique salle d'eau Sagara noir Mat ASTRO LIGHTING">Applique salle d'eau Sagara noir Mat ASTRO LIGHTING</option>
+          <option value="Bidon eco prim universel 20kg mapei 200gr/m²">Bidon eco prim universel 20kg mapei 200gr/m²</option>
+          <option value="COLLE Fixit blanc 290ml ou  Bostik MS 107 ou MSPOOL">COLLE Fixit blanc 290ml ou  Bostik MS 107 ou MSPOOL</option>
+          <option value="Chaise Trill Nardi - Coloris TORTORA Fibre de verre">Chaise Trill Nardi - Coloris TORTORA Fibre de verre</option>
+          <option value="Colle contact gel 4,25 kg - PATTEX">Colle contact gel 4,25 kg - PATTEX</option>
+          <option value="Colle fixation plinthes - BOSTIK Réf. 850983">Colle fixation plinthes - BOSTIK Réf. 850983</option>
+          <option value="Corbeille ovale polypropylène 6L Référence:240 00">Corbeille ovale polypropylène 6L Référence:240 00</option>
+          <option value="DIFF. OPAL LZR L/LZR L-R 2,01M">DIFF. OPAL LZR L/LZR L-R 2,01M</option>
+          <option value="Data: 09-05-2025 / Oportunitate de referință: 0035 /Versiune: 3">Data: 09-05-2025 / Oportunitate de referință: 0035 /Versiune: 3</option>
+          <option value="Distributeur papier rouleau simple White Serenity Référence:2321 00 00">Distributeur papier rouleau simple White Serenity Référence:2321 00 00</option>
+          <option value="ELEC - 4,5K/phase (x7)">ELEC - 4,5K/phase (x7)</option>
+          <option value="ENSEMBLE BÉQUILLE DIANE SUR ROSACE BLANCHE AVEC ROSACE A CONDAMNATION">ENSEMBLE BÉQUILLE DIANE SUR ROSACE BLANCHE AVEC ROSACE A CONDAMNATION</option>
+          <option value="EUROFIX TACK PLUS 150gr/m²">EUROFIX TACK PLUS 150gr/m²</option>
+          <option value="Ferme-porte à pignon excentré et crémaillère GR 400 - GROOM FERMETURES">Ferme-porte à pignon excentré et crémaillère GR 400 - GROOM FERMETURES</option>
+          <option value="Fib'Air A2 NETO / Fib'Air ALU A2">Fib'Air A2 NETO / Fib'Air ALU A2</option>
+          <option value="Forbo allura decibel 8WSM03 dune smooth oak au m² (268.00 CS)">Forbo allura decibel 8WSM03 dune smooth oak au m² (268.00 CS)</option>
+          <option value="Gaine alu 125 en ML">Gaine alu 125 en ML</option>
+          <option value="Grohtherm 500 douche avec ensemble Tempesta 110 1 jet 8l barre 600 Chromé Réf. 34808001">Grohtherm 500 douche avec ensemble Tempesta 110 1 jet 8l barre 600 Chromé Réf. 34808001</option>
+          <option value="Hager - Goulotte de distribution lifea LFF 30x30mm 1 compartivement PVC Blanc - LFF3003009016 - 2ml">Hager - Goulotte de distribution lifea LFF 30x30mm 1 compartivement PVC Blanc - LFF3003009016 - 2ml</option>
+          <option value="Hager - Socle pour plinthe SL 20x80mm Noir - SL200801 - 2ml Hager - Couvercle pour plinthe SL 20x80mm Graphite Noir - SL2008029011 - 2ml">Hager - Socle pour plinthe SL 20x80mm Noir - SL200801 - 2ml Hager - Couvercle pour plinthe SL 20x80mm Graphite Noir - SL2008029011 - 2ml</option>
+          <option value="INTERRUPTEUR A BADGE - CM0010 complet">INTERRUPTEUR A BADGE - CM0010 complet</option>
+          <option value="Interrupteur double Surface Céliane blanc compris : boite d'encastrement simple, support, interrupteur double, enjoliveur & plaque finition">Interrupteur double Surface Céliane blanc compris : boite d'encastrement simple, support, interrupteur double, enjoliveur & plaque finition</option>
+          <option value="Interrupteur simple Surface Céliane blanc compris : boite d'encastrement, support, interrupteur, enjoliveur & plaque finition">Interrupteur simple Surface Céliane blanc compris : boite d'encastrement, support, interrupteur, enjoliveur & plaque finition</option>
+          <option value="Kit de réparation receveurs Alterna Daily'O, Daily'C et Daily'L blanc">Kit de réparation receveurs Alterna Daily'O, Daily'C et Daily'L blanc</option>
+          <option value="L04 Spot isolé TARGETTI">L04 Spot isolé TARGETTI</option>
+          <option value="LISEUSE Applique radar 1 x LED 3 2 blanc mat 05-6488-14-14 LedC4">LISEUSE Applique radar 1 x LED 3 2 blanc mat 05-6488-14-14 LedC4</option>
+          <option value="LUXA 103 S360-100-12 DE-UP WH">LUXA 103 S360-100-12 DE-UP WH</option>
+          <option value="LUXA 103 S360-100-28 DE-UP WH">LUXA 103 S360-100-28 DE-UP WH</option>
+          <option value="LVT Allura 62513 Grigio Concrete 100x100cm FORBO">LVT Allura 62513 Grigio Concrete 100x100cm FORBO</option>
+          <option value="Lavabo Geberit Acanto 500.620.01.2">Lavabo Geberit Acanto 500.620.01.2</option>
+          <option value="Lot de 8 panneaux laine de roche phonique rocksilence - Ep.40 mm lambda 34 R=1,35 L.120 x l.60 cm - ROCKWOOL">Lot de 8 panneaux laine de roche phonique rocksilence - Ep.40 mm lambda 34 R=1,35 L.120 x l.60 cm - ROCKWOOL</option>
+          <option value="MANCHON PLACO AUSTRALE D125">MANCHON PLACO AUSTRALE D125</option>
+          <option value="Mitigeur lavabo Eurosmart réf : 33265003">Mitigeur lavabo Eurosmart réf : 33265003</option>
+          <option value="Mortier adhésif en poudre 25 kg">Mortier adhésif en poudre 25 kg</option>
+          <option value="OFFRE 1829/25">OFFRE 1829/25</option>
+          <option value="PACK BATI SUPPORT COMPLET Geberit + cuvette Renova Compact 203245000">PACK BATI SUPPORT COMPLET Geberit + cuvette Renova Compact 203245000</option>
+          <option value="PC simple Surface Céliane blanc compris : boite d'encastrement, support, prise 2P+T, enjoliveur & plaque finition">PC simple Surface Céliane blanc compris : boite d'encastrement, support, prise 2P+T, enjoliveur & plaque finition</option>
+          <option value="PC simple USB-C Surface Céliane blanc compris : boite d'encastrement, support, prise 2P+T USB C intégré, enjoliveur & plaque finition">PC simple USB-C Surface Céliane blanc compris : boite d'encastrement, support, prise 2P+T USB C intégré, enjoliveur & plaque finition</option>
+          <option value="PEINTURES & SOLS">PEINTURES & SOLS</option>
+          <option value="PROJECTEUR SUR RAIL LED SP 8W - 8W 23V diamètre 40 - 2700K - couleur BLANC TARGETTI">PROJECTEUR SUR RAIL LED SP 8W - 8W 23V diamètre 40 - 2700K - couleur BLANC TARGETTI</option>
+          <option value="Panneau en pvc cellulaire durci imprimé reboost carré écossais verni ép 6mm de hauteur 1100mm x largeur 700mm (wc)">Panneau en pvc cellulaire durci imprimé reboost carré écossais verni ép 6mm de hauteur 1100mm x largeur 700mm (wc)</option>
+          <option value="Panneau en pvc cellulaire durci imprimé reboost carré écossais verni ép 6mm de hauteur 2350mm x largeur 811mm (lavabo) 2200x800x6mm ?">Panneau en pvc cellulaire durci imprimé reboost carré écossais verni ép 6mm de hauteur 2350mm x largeur 811mm (lavabo) 2200x800x6mm ?</option>
+          <option value="Paroi d'angle 90(gauche)x70(droite)">Paroi d'angle 90(gauche)x70(droite)</option>
+          <option value="Patère simple Continental Référence:381 00 00">Patère simple Continental Référence:381 00 00</option>
+          <option value="Plaque de fixation pour raccord à sertir entraxe 150 PER ROBIFIX D16">Plaque de fixation pour raccord à sertir entraxe 150 PER ROBIFIX D16</option>
+          <option value="Plaque de plâtre BA13 hydrofuge NF H.250 x l.120 cm">Plaque de plâtre BA13 hydrofuge NF H.250 x l.120 cm</option>
+          <option value="Plaque de plâtre BA13 standard NF H.250 x l.120 cm">Plaque de plâtre BA13 standard NF H.250 x l.120 cm</option>
+          <option value="Plinthe FORBO PVC 6500 80mm 2ml/unité (27.00 CAR)">Plinthe FORBO PVC 6500 80mm 2ml/unité (27.00 CAR)</option>
+          <option value="Plinthe FORBO PVC BLANC 80mm 2ml/unité (9.00 CAR)">Plinthe FORBO PVC BLANC 80mm 2ml/unité (9.00 CAR)</option>
+          <option value="Porte-papier de réserve Continental Référence:324 01 01">Porte-papier de réserve Continental Référence:324 01 01</option>
+          <option value="Pot balai court à poser Référence:274 00">Pot balai court à poser Référence:274 00</option>
+          <option value="Prise + Inter VV Surface Céliane blanc compris : boite d'encastrement double, support double, prise 2P+T USB C intégré, inter VV, enjoliveurs, plaque finition double">Prise + Inter VV Surface Céliane blanc compris : boite d'encastrement double, support double, prise 2P+T USB C intégré, inter VV, enjoliveurs, plaque finition double</option>
+          <option value="Prise 2x2P+T USB C intégré Surface Céliane blanc compris : boite d'encastrement double, support double, 2x prise 2x2P+T USB C intégré, enjoliveurs, plaque finition double">Prise 2x2P+T USB C intégré Surface Céliane blanc compris : boite d'encastrement double, support double, 2x prise 2x2P+T USB C intégré, enjoliveurs, plaque finition double</option>
+          <option value="Prise TV + PC Surface Céliane blanc compris : boite d'encastrement DOUBLE, support DOUBLE, prise 2P+T, prise tv, enjoliveurs, plaque finition double">Prise TV + PC Surface Céliane blanc compris : boite d'encastrement DOUBLE, support DOUBLE, prise 2P+T, prise tv, enjoliveurs, plaque finition double</option>
+          <option value="Profilé PVC Angle/Plat L2350mm - BLANC">Profilé PVC Angle/Plat L2350mm - BLANC</option>
+          <option value="Profilé cache chant parois 6mm long. 2,5m - BLANC laqué">Profilé cache chant parois 6mm long. 2,5m - BLANC laqué</option>
+          <option value="RAIL 6010 IBIS STANDARD BLANC - L215">RAIL 6010 IBIS STANDARD BLANC - L215</option>
+          <option value="RUBAN 3M 2700K 720LM/M IP20">RUBAN 3M 2700K 720LM/M IP20</option>
+          <option value="Ragréage P3 intérieur 25 kg - Planidur PRB 1,5 kg/m²/mm (base 2mm)">Ragréage P3 intérieur 25 kg - Planidur PRB 1,5 kg/m²/mm (base 2mm)</option>
+          <option value="Rail standard blanc (2 à 200cm) compris embout de rail, étrier de fixation au plafond et alimentation latérale en bout de rail. TARGETTI">Rail standard blanc (2 à 200cm) compris embout de rail, étrier de fixation au plafond et alimentation latérale en bout de rail. TARGETTI</option>
+          <option value="Receveur Alterna Daily'O 120 x 80 cm ardoise blanc recoupable">Receveur Alterna Daily'O 120 x 80 cm ardoise blanc recoupable</option>
+          <option value="Receveur de douche ALTERNA Daily'O 90x70cm blanc effet ardoise antidérapant">Receveur de douche ALTERNA Daily'O 90x70cm blanc effet ardoise antidérapant</option>
+          <option value="Réf. 10896011 Ruban adhésif toilé gris l.50 mm x L.50 m TESA">Réf. 10896011 Ruban adhésif toilé gris l.50 mm x L.50 m TESA</option>
+          <option value="Réf. 10962560 Ruban de masquage de précision surface délicate l.25 mm x L.50 m - TESA">Réf. 10962560 Ruban de masquage de précision surface délicate l.25 mm x L.50 m - TESA</option>
+          <option value="Réf. 1221024 Bloc-porte isoplan prépeint Larg.63cm  Huiss72 mm">Réf. 1221024 Bloc-porte isoplan prépeint Larg.63cm  Huiss72 mm</option>
+          <option value="Réf. 1236942 - Bonde douche extra-plate turboflow xs ø90 nicoll">Réf. 1236942 - Bonde douche extra-plate turboflow xs ø90 nicoll</option>
+          <option value="Réf. 1267742 Vis autoforeuse Diam. 3,5 x 9,5 mm Boîte de 500 - ISOLPRO">Réf. 1267742 Vis autoforeuse Diam. 3,5 x 9,5 mm Boîte de 500 - ISOLPRO</option>
+          <option value="Réf. 1338834 Cheville arpon multi matériaux x Diam.8 x 32mm X 50 - SPIT">Réf. 1338834 Cheville arpon multi matériaux x Diam.8 x 32mm X 50 - SPIT</option>
+          <option value="Réf. 1339226 Cheville arpon multi matériaux x Diam.6 x 25mm X 50 - SPIT">Réf. 1339226 Cheville arpon multi matériaux x Diam.6 x 25mm X 50 - SPIT</option>
+          <option value="Réf. 1339835 Cheville autoforeuse zamak driva + vis tête ronde Diam.4,5x35 mm x 100 - SPIT">Réf. 1339835 Cheville autoforeuse zamak driva + vis tête ronde Diam.4,5x35 mm x 100 - SPIT</option>
+          <option value="Réf. 1353471 VRAC CHEVILLES MÉTAL.Ø5X37+VISØ5X43 X315">Réf. 1353471 VRAC CHEVILLES MÉTAL.Ø5X37+VISØ5X43 X315</option>
+          <option value="Réf. 1353492 VRAC CHEVILLES MÉTAL.Ø5X63+VISØ5X72 X238">Réf. 1353492 VRAC CHEVILLES MÉTAL.Ø5X63+VISØ5X72 X238</option>
+          <option value="Réf. 138033 Champlat  6 x 30 mm Long.2,4 m - SOTRINBOIS LOT DE 10">Réf. 138033 Champlat  6 x 30 mm Long.2,4 m - SOTRINBOIS LOT DE 10</option>
+          <option value="Réf. 1388590 Silicone sanitaire acétique translucide 280 ml">Réf. 1388590 Silicone sanitaire acétique translucide 280 ml</option>
+          <option value="Réf. 1401162 Silicone sanitaire acétique blanc 280 ml">Réf. 1401162 Silicone sanitaire acétique blanc 280 ml</option>
+          <option value="Réf. 1406160 Mastic de rebouchage Soudacryl FF acrylique blanc 300 ml - SOUDAL">Réf. 1406160 Mastic de rebouchage Soudacryl FF acrylique blanc 300 ml - SOUDAL</option>
+          <option value="Réf. 1493590 Ruban de masquage adhésif pour surfaces lisses l.50 mm x L.50 m - ROTA (lot de 6)">Réf. 1493590 Ruban de masquage adhésif pour surfaces lisses l.50 mm x L.50 m - ROTA (lot de 6)</option>
+          <option value="Réf. 1544641 FILM POLYETHYLENE 40µ 3X25M ONDULINE">Réf. 1544641 FILM POLYETHYLENE 40µ 3X25M ONDULINE</option>
+          <option value="Réf. 1569701 Ruban de masquage adhésif pour surfaces délicates l.36 mm x L.50 m - 3M (lot de 3)">Réf. 1569701 Ruban de masquage adhésif pour surfaces délicates l.36 mm x L.50 m - 3M (lot de 3)</option>
+          <option value="Réf. 25014595 3M PT206036 Ruban de masquage pour peinture 3M™ 2060 vert clair (L x l) 50 m x 36 mm 1 pc(s)">Réf. 25014595 3M PT206036 Ruban de masquage pour peinture 3M™ 2060 vert clair (L x l) 50 m x 36 mm 1 pc(s)</option>
+          <option value="Réf. 283724 CARREAU PLATRE HYDRO PLEIN 66X50X7">Réf. 283724 CARREAU PLATRE HYDRO PLEIN 66X50X7</option>
+          <option value="Réf. 334180 Montant métallique 48/35 mm Long.2,50 m NF - ISOLPRO">Réf. 334180 Montant métallique 48/35 mm Long.2,50 m NF - ISOLPRO</option>
+          <option value="Réf. 334194 Rail métallique 48/28 mm Long.3 m NF - ISOLPRO">Réf. 334194 Rail métallique 48/28 mm Long.3 m NF - ISOLPRO</option>
+          <option value="Réf. 652911 Raccord mâle M.12x17(3/8'') multicouche à sertir Diam.16 mm">Réf. 652911 Raccord mâle M.12x17(3/8'') multicouche à sertir Diam.16 mm</option>
+          <option value="Réf. 753851 Butoir de porte cylindre - CHAINEY">Réf. 753851 Butoir de porte cylindre - CHAINEY</option>
+          <option value="Réf. 811293 Gants de protection pour travaux de précision T.10 - KAPRIOL">Réf. 811293 Gants de protection pour travaux de précision T.10 - KAPRIOL</option>
+          <option value="Réf. 92055431 Bouchon Laiton Femelle 12x17 (3/8) x2 bouchons NOYON & THIEBAULT">Réf. 92055431 Bouchon Laiton Femelle 12x17 (3/8) x2 bouchons NOYON & THIEBAULT</option>
+          <option value="Réf. 940121 Gants de protection agilité T.9 - DELTA PLUS">Réf. 940121 Gants de protection agilité T.9 - DELTA PLUS</option>
+          <option value="SHOWTIME GRAPHIC IBIS REBOOST Référence 951273 Qualité A Format 200 CM 5.00 ROL 400.00M2">SHOWTIME GRAPHIC IBIS REBOOST Référence 951273 Qualité A Format 200 CM 5.00 ROL 400.00M2</option>
+          <option value="SMART DESIGN P XXL SS 110 BLANC TRANSPARENTHT 2000X L 1100 MM (FIXE 400+ PVT 600 MM)">SMART DESIGN P XXL SS 110 BLANC TRANSPARENTHT 2000X L 1100 MM (FIXE 400+ PVT 600 MM)</option>
+          <option value="SMART DESIGN P XXL SS 110 BLANC TRANSPARENTHT 2000X L 1100 MM (FIXE 450+ PVT 650 MM)">SMART DESIGN P XXL SS 110 BLANC TRANSPARENTHT 2000X L 1100 MM (FIXE 450+ PVT 650 MM)</option>
+          <option value="STICKAGE PORTE - D-202501-046">STICKAGE PORTE - D-202501-046</option>
+          <option value="Sarlibain Surestep 171032 smoke au m² (5.00 ROL 250.00M2)">Sarlibain Surestep 171032 smoke au m² (5.00 ROL 250.00M2)</option>
+          <option value="Siphon à tube plongeur Geberit pour lavabo, sortie horizontale">Siphon à tube plongeur Geberit pour lavabo, sortie horizontale</option>
+          <option value="Spot encastré blanc collerette blanche IP 65 30° 2700K">Spot encastré blanc collerette blanche IP 65 30° 2700K</option>
+          <option value="Structure lit superposé">Structure lit superposé</option>
+          <option value="TETE MICROFLEX PLIS SIMPLE (PMPS) NOCTURNE M1 UNI PERLE - L215xH249 1 pan">TETE MICROFLEX PLIS SIMPLE (PMPS) NOCTURNE M1 UNI PERLE - L215xH249 1 pan</option>
+          <option value="Tablette wc en pvc cellulaire durci 150x700mm">Tablette wc en pvc cellulaire durci 150x700mm</option>
+          <option value="Textile aiguilleté couleur 900279 VS FORBO (remontées plinthes) Rouleau de 80m² (40x2m)">Textile aiguilleté couleur 900279 VS FORBO (remontées plinthes) Rouleau de 80m² (40x2m)</option>
+          <option value="Trappe de visite métallique Tempo Softline Ventil l 600X600 mm, ouverture clé carré, ral 9016">Trappe de visite métallique Tempo Softline Ventil l 600X600 mm, ouverture clé carré, ral 9016</option>
+          <option value="Tube PER prégainé DUO D16mm ep 1,5mm couronne 50m (env 5ml/chambre)">Tube PER prégainé DUO D16mm ep 1,5mm couronne 50m (env 5ml/chambre)</option>
+          <option value="Té égal PER à sertir D16">Té égal PER à sertir D16</option>
+          <option value="Union droit égal PER à sertir  D16">Union droit égal PER à sertir  D16</option>
+          <option value="Vis 4,0x30 PZ2">Vis 4,0x30 PZ2</option>
+          <option value="Vis 4,5x45 PZ2">Vis 4,5x45 PZ2</option>
+          <option value="Vis 5x50 PZ2">Vis 5x50 PZ2</option>
+          <option value="panneau en pvc cellulaire durci imprimé reboost carré écossais verni de  (longueur receveur 90x70) 2200x900x6mm">panneau en pvc cellulaire durci imprimé reboost carré écossais verni de  (longueur receveur 90x70) 2200x900x6mm</option>
+          <option value="panneau en pvc cellulaire durci imprimé reboost carré écossais verni de ( longueur receveur standard) 2200x1100x6mm">panneau en pvc cellulaire durci imprimé reboost carré écossais verni de ( longueur receveur standard) 2200x1100x6mm</option>
+          <option value="panneau en pvc cellulaire durci imprimé reboost carré écossais verni de (largeur receveur standard + 90x70) 2200x700x6mm">panneau en pvc cellulaire durci imprimé reboost carré écossais verni de (largeur receveur standard + 90x70) 2200x700x6mm</option>
+          <option value="vis pour plaque de plâtre 3,5 x 25 mm boite 1000vis">vis pour plaque de plâtre 3,5 x 25 mm boite 1000vis</option>
+        </select>
       </div>
       <div class="mb-3">
         <label for="reference" class="form-label">Référence</label>
@@ -184,6 +301,37 @@ select#emplacementId.form-control {
       <div class="mb-3">
         <label for="prix" class="form-label">Prix</label>
         <input type="number" step="0.01" name="prix" id="prix" class="form-control" required>
+      </div>
+      <div class="mb-3">
+        <label for="fournisseur" class="form-label">Fournisseur</label>
+        <input type="text" name="fournisseur" id="fournisseurInput" class="form-control">
+        <select id="fournisseurSelect" class="form-select mt-2">
+          <option value="">-- Sélectionner un fournisseur --</option>
+          <option value="4 Pieds">4 Pieds</option>
+          <option value="BRICOMAN">BRICOMAN</option>
+          <option value="CEDEO">CEDEO</option>
+          <option value="FORBO">FORBO</option>
+          <option value="FOUSSIER">FOUSSIER</option>
+          <option value="France'AIR">France'AIR</option>
+          <option value="HUSSEIN">HUSSEIN</option>
+          <option value="JM EXIM">JM EXIM</option>
+          <option value="José">José</option>
+          <option value="KINEDO">KINEDO</option>
+          <option value="LES RIPEURS">LES RIPEURS</option>
+          <option value="MPI">MPI</option>
+          <option value="ODF">ODF</option>
+          <option value="PIXELO">PIXELO</option>
+          <option value="RICHARDSON">RICHARDSON</option>
+          <option value="SANITINO">SANITINO</option>
+          <option value="SONEPAR">SONEPAR</option>
+          <option value="SOTEXPRO">SOTEXPRO</option>
+          <option value="STMI">STMI</option>
+          <option value="TARGETTI">TARGETTI</option>
+          <option value="TEMPO">TEMPO</option>
+          <option value="Wurth">Wurth</option>
+          <option value="pure-com">pure-com</option>
+          <option value="Autre">Autre</option>
+        </select>
       </div>
       <div class="mb-3">
         <label for="categorie" class="form-label">Catégorie</label>
@@ -253,5 +401,22 @@ select#emplacementId.form-control {
     <p><a href="/chantier" class="btn btn-secondary mt-3">Retour au Dashboard Chantier</a></p>
   </div>
   <script src="/js/bootstrap.bundle.min.js"></script>
+  <script>
+    const fournisseurSelect = document.getElementById('fournisseurSelect');
+    const fournisseurInput = document.getElementById('fournisseurInput');
+    if (fournisseurSelect) {
+      fournisseurSelect.addEventListener('change', () => {
+        fournisseurInput.value = fournisseurSelect.value;
+      });
+    }
+
+    const designationSelect = document.getElementById('designationSelect');
+    const designationInput = document.getElementById('nom');
+    if (designationSelect) {
+      designationSelect.addEventListener('change', () => {
+        designationInput.value = designationSelect.value;
+      });
+    }
+  </script>
 </body>
 </html>

--- a/views/chantier/modifierMaterielChantier.ejs
+++ b/views/chantier/modifierMaterielChantier.ejs
@@ -25,9 +25,70 @@
       </div>
 
       <div class="mb-3">
-        <label for="nomMateriel" class="form-label">Nom du matériel</label>
-        <input type="text" class="form-control" id="nomMateriel" name="nomMateriel" value="<%= mc.materiel.nom %>" required>
-      </div>
+        <label for="nomMateriel" class="form-label">Désignation</label>
+        <input type="text" class="form-control" id="nomMateriel" name="nomMateriel" value="<%= mc.materiel.nom %>">
+        <select id="designationSelect" class="form-select mt-2">
+          <option value="">-- Sélectionner une désignation --</option>
+          <option value="PROFIL NR LAZER L-R 2,01M">PROFIL NR LAZER L-R 2,01M</option>
+          <option value="2 Conteneurs + 1 Algeco + Benne DIB & Bois">2 Conteneurs + 1 Algeco + Benne DIB & Bois</option>
+          <option value="ALIM 15W IP20 24VDC">ALIM 15W IP20 24VDC</option>
+          <option value="AUSTRALE DIAM 125">AUSTRALE DIAM 125</option>
+          <option value="Applique salle d'eau Sagara noir Mat ASTRO LIGHTING">Applique salle d'eau Sagara noir Mat ASTRO LIGHTING</option>
+          <option value="Bidon eco prim universel 20kg mapei 200gr/m²">Bidon eco prim universel 20kg mapei 200gr/m²</option>
+          <option value="COLLE Fixit blanc 290ml ou  Bostik MS 107 ou MSPOOL">COLLE Fixit blanc 290ml ou  Bostik MS 107 ou MSPOOL</option>
+          <option value="Chaise Trill Nardi - Coloris TORTORA Fibre de verre">Chaise Trill Nardi - Coloris TORTORA Fibre de verre</option>
+          <option value="Colle contact gel 4,25 kg - PATTEX">Colle contact gel 4,25 kg - PATTEX</option>
+          <option value="Colle fixation plinthes - BOSTIK Réf. 850983">Colle fixation plinthes - BOSTIK Réf. 850983</option>
+          <option value="Corbeille ovale polypropylène 6L Référence:240 00">Corbeille ovale polypropylène 6L Référence:240 00</option>
+          <option value="DIFF. OPAL LZR L/LZR L-R 2,01M">DIFF. OPAL LZR L/LZR L-R 2,01M</option>
+          <option value="Data: 09-05-2025 / Oportunitate de referință: 0035 /Versiune: 3">Data: 09-05-2025 / Oportunitate de referință: 0035 /Versiune: 3</option>
+          <option value="Distributeur papier rouleau simple White Serenity Référence:2321 00 00">Distributeur papier rouleau simple White Serenity Référence:2321 00 00</option>
+          <option value="ELEC - 4,5K/phase (x7)">ELEC - 4,5K/phase (x7)</option>
+          <option value="ENSEMBLE BÉQUILLE DIANE SUR ROSACE BLANCHE AVEC ROSACE A CONDAMNATION">ENSEMBLE BÉQUILLE DIANE SUR ROSACE BLANCHE AVEC ROSACE A CONDAMNATION</option>
+          <option value="EUROFIX TACK PLUS 150gr/m²">EUROFIX TACK PLUS 150gr/m²</option>
+          <option value="Ferme-porte à pignon excentré et crémaillère GR 400 - GROOM FERMETURES">Ferme-porte à pignon excentré et crémaillère GR 400 - GROOM FERMETURES</option>
+          <option value="Fib'Air A2 NETO / Fib'Air ALU A2">Fib'Air A2 NETO / Fib'Air ALU A2</option>
+          <option value="Forbo allura decibel 8WSM03 dune smooth oak au m² (268.00 CS)">Forbo allura decibel 8WSM03 dune smooth oak au m² (268.00 CS)</option>
+          <option value="Gaine alu 125 en ML">Gaine alu 125 en ML</option>
+          <option value="Grohtherm 500 douche avec ensemble Tempesta 110 1 jet 8l barre 600 Chromé Réf. 34808001">Grohtherm 500 douche avec ensemble Tempesta 110 1 jet 8l barre 600 Chromé Réf. 34808001</option>
+          <option value="Hager - Goulotte de distribution lifea LFF 30x30mm 1 compartivement PVC Blanc - LFF3003009016 - 2ml">Hager - Goulotte de distribution lifea LFF 30x30mm 1 compartivement PVC Blanc - LFF3003009016 - 2ml</option>
+          <option value="Hager - Socle pour plinthe SL 20x80mm Noir - SL200801 - 2ml Hager - Couvercle pour plinthe SL 20x80mm Graphite Noir - SL2008029011 - 2ml">Hager - Socle pour plinthe SL 20x80mm Noir - SL200801 - 2ml Hager - Couvercle pour plinthe SL 20x80mm Graphite Noir - SL2008029011 - 2ml</option>
+          <option value="INTERRUPTEUR A BADGE - CM0010 complet">INTERRUPTEUR A BADGE - CM0010 complet</option>
+          <option value="Interrupteur double Surface Céliane blanc compris : boite d'encastrement simple, support, interrupteur double, enjoliveur & plaque finition">Interrupteur double Surface Céliane blanc compris : boite d'encastrement simple, support, interrupteur double, enjoliveur & plaque finition</option>
+          <option value="Interrupteur simple Surface Céliane blanc compris : boite d'encastrement, support, interrupteur, enjoliveur & plaque finition">Interrupteur simple Surface Céliane blanc compris : boite d'encastrement, support, interrupteur, enjoliveur & plaque finition</option>
+          <option value="Kit de réparation receveurs Alterna Daily'O, Daily'C et Daily'L blanc">Kit de réparation receveurs Alterna Daily'O, Daily'C et Daily'L blanc</option>
+          <option value="L04 Spot isolé TARGETTI">L04 Spot isolé TARGETTI</option>
+          <option value="LISEUSE Applique radar 1 x LED 3 2 blanc mat 05-6488-14-14 LedC4">LISEUSE Applique radar 1 x LED 3 2 blanc mat 05-6488-14-14 LedC4</option>
+          <option value="LUXA 103 S360-100-12 DE-UP WH">LUXA 103 S360-100-12 DE-UP WH</option>
+          <option value="LUXA 103 S360-100-28 DE-UP WH">LUXA 103 S360-100-28 DE-UP WH</option>
+          <option value="LVT Allura 62513 Grigio Concrete 100x100cm FORBO">LVT Allura 62513 Grigio Concrete 100x100cm FORBO</option>
+          <option value="Lavabo Geberit Acanto 500.620.01.2">Lavabo Geberit Acanto 500.620.01.2</option>
+          <option value="Lot de 8 panneaux laine de roche phonique rocksilence - Ep.40 mm lambda 34 R=1,35 L.120 x l.60 cm - ROCKWOOL">Lot de 8 panneaux laine de roche phonique rocksilence - Ep.40 mm lambda 34 R=1,35 L.120 x l.60 cm - ROCKWOOL</option>
+          <option value="MANCHON PLACO AUSTRALE D125">MANCHON PLACO AUSTRALE D125</option>
+          <option value="Mitigeur lavabo Eurosmart réf : 33265003">Mitigeur lavabo Eurosmart réf : 33265003</option>
+          <option value="Mortier adhésif en poudre 25 kg">Mortier adhésif en poudre 25 kg</option>
+          <option value="OFFRE 1829/25">OFFRE 1829/25</option>
+          <option value="PACK BATI SUPPORT COMPLET Geberit + cuvette Renova Compact 203245000">PACK BATI SUPPORT COMPLET Geberit + cuvette Renova Compact 203245000</option>
+          <option value="PC simple Surface Céliane blanc compris : boite d'encastrement, support, prise 2P+T, enjoliveur & plaque finition">PC simple Surface Céliane blanc compris : boite d'encastrement, support, prise 2P+T, enjoliveur & plaque finition</option>
+          <option value="PC simple USB-C Surface Céliane blanc compris : boite d'encastrement, support, prise 2P+T USB C intégré, enjoliveur & plaque finition">PC simple USB-C Surface Céliane blanc compris : boite d'encastrement, support, prise 2P+T USB C intégré, enjoliveur & plaque finition</option>
+          <option value="PEINTURES & SOLS">PEINTURES & SOLS</option>
+          <option value="PROJECTEUR SUR RAIL LED SP 8W - 8W 23V diamètre 40 - 2700K - couleur BLANC TARGETTI">PROJECTEUR SUR RAIL LED SP 8W - 8W 23V diamètre 40 - 2700K - couleur BLANC TARGETTI</option>
+          <option value="Panneau en pvc cellulaire durci imprimé reboost carré écossais verni ép 6mm de hauteur 1100mm x largeur 700mm (wc)">Panneau en pvc cellulaire durci imprimé reboost carré écossais verni ép 6mm de hauteur 1100mm x largeur 700mm (wc)</option>
+          <option value="Panneau en pvc cellulaire durci imprimé reboost carré écossais verni ép 6mm de hauteur 2350mm x largeur 811mm (lavabo) 2200x800x6mm ?">Panneau en pvc cellulaire durci imprimé reboost carré écossais verni ép 6mm de hauteur 2350mm x largeur 811mm (lavabo) 2200x800x6mm ?</option>
+          <option value="Paroi d'angle 90(gauche)x70(droite)">Paroi d'angle 90(gauche)x70(droite)</option>
+          <option value="Patère simple Continental Référence:381 00 00">Patère simple Continental Référence:381 00 00</option>
+          <option value="Plaque de fixation pour raccord à sertir entraxe 150 PER ROBIFIX D16">Plaque de fixation pour raccord à sertir entraxe 150 PER ROBIFIX D16</option>
+          <option value="Plaque de plâtre BA13 hydrofuge NF H.250 x l.120 cm">Plaque de plâtre BA13 hydrofuge NF H.250 x l.120 cm</option>
+          <option value="Plaque de plâtre BA13 standard NF H.250 x l.120 cm">Plaque de plâtre BA13 standard NF H.250 x l.120 cm</option>
+          <option value="Plinthe FORBO PVC 6500 80mm 2ml/unité (27.00 CAR)">Plinthe FORBO PVC 6500 80mm 2ml/unité (27.00 CAR)</option>
+          <option value="Plinthe FORBO PVC BLANC 80mm 2ml/unité (9.00 CAR)">Plinthe FORBO PVC BLANC 80mm 2ml/unité (9.00 CAR)</option>
+          <option value="Porte-papier de réserve Continental Référence:324 01 01">Porte-papier de réserve Continental Référence:324 01 01</option>
+          <option value="Pot balai court à poser Référence:274 00">Pot balai court à poser Référence:274 00</option>
+          <option value="Prise + Inter VV Surface Céliane blanc compris : boite d'encastrement double, support double, prise 2P+T USB C intégré, inter VV, enjoliveurs, plaque finition double">Prise + Inter VV Surface Céliane blanc compris : boite d'encastrement double, support double, prise 2P+T USB C intégré, inter VV, enjoliveurs, plaque finition double</option>
+          <option value="Prise 2x2P+T USB C intégré Surface Céliane blanc compris : boite d'encastrement double, support double, 2x prise 2x2P+T USB C intégré, enjoliveurs, plaque finition double">Prise 2x2P+T USB C intégré Surface Céliane blanc compris : boite d'encastrement double, support double, 2x prise 2x2P+T USB C intégré, enjoliveurs, plaque finition double</option>
+          <option value="Prise TV + PC Surface Céliane blanc compris : boite d'encastrement DOUBLE, support DOUBLE, prise 2P+T, prise tv, enjoliveurs, plaque finition double">Prise TV + PC Surface Céliane blanc compris : boite d'encastrement DOUBLE, support DOUBLE, prise 2P+T, prise tv, enjoliveurs, plaque finition double</option>
+          <option value="Profilé PVC Angle/Plat L2350mm - BLANC">Profilé PVC Angle/Plat L2350mm - BLANC</option>
+          <option value="Profilé cache chant parois 6mm long. 2,5m - BLANC laqué">Profilé cache chant parois 6mm long. 2,5m - BLANC laqué</option>
 
       <div class="mb-3">
   <label for="categorie" class="form-label">Catégorie</label>
@@ -57,6 +118,37 @@
               <%= e.nom %> (Chantier: <%= e.chantierId %>)
             </option>
           <% }) %>
+        </select>
+      </div>
+      <div class="mb-3">
+        <label for="fournisseur" class="form-label">Fournisseur</label>
+        <input type="text" name="fournisseur" id="fournisseurInput" class="form-control" value="<%= mc.materiel.fournisseur || '' %>">
+        <select id="fournisseurSelect" class="form-select mt-2">
+          <option value="">-- Sélectionner un fournisseur --</option>
+          <option value="4 Pieds">4 Pieds</option>
+          <option value="BRICOMAN">BRICOMAN</option>
+          <option value="CEDEO">CEDEO</option>
+          <option value="FORBO">FORBO</option>
+          <option value="FOUSSIER">FOUSSIER</option>
+          <option value="France'AIR">France'AIR</option>
+          <option value="HUSSEIN">HUSSEIN</option>
+          <option value="JM EXIM">JM EXIM</option>
+          <option value="José">José</option>
+          <option value="KINEDO">KINEDO</option>
+          <option value="LES RIPEURS">LES RIPEURS</option>
+          <option value="MPI">MPI</option>
+          <option value="ODF">ODF</option>
+          <option value="PIXELO">PIXELO</option>
+          <option value="RICHARDSON">RICHARDSON</option>
+          <option value="SANITINO">SANITINO</option>
+          <option value="SONEPAR">SONEPAR</option>
+          <option value="SOTEXPRO">SOTEXPRO</option>
+          <option value="STMI">STMI</option>
+          <option value="TARGETTI">TARGETTI</option>
+          <option value="TEMPO">TEMPO</option>
+          <option value="Wurth">Wurth</option>
+          <option value="pure-com">pure-com</option>
+          <option value="Autre">Autre</option>
         </select>
       </div>
 
@@ -127,5 +219,22 @@
 </script>
 
   <script src="/js/bootstrap.bundle.min.js"></script>
+  <script>
+    const fSelect = document.getElementById('fournisseurSelect');
+    const fInput = document.getElementById('fournisseurInput');
+    if (fSelect) {
+      fSelect.addEventListener('change', () => {
+        fInput.value = fSelect.value;
+      });
+    }
+
+    const dSelect = document.getElementById('designationSelect');
+    const dInput = document.getElementById('nomMateriel');
+    if (dSelect) {
+      dSelect.addEventListener('change', () => {
+        dInput.value = dSelect.value;
+      });
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extend `Materiel` model with `fournisseur`
- save `fournisseur` when creating or editing chantier materials
- add designation dropdown lists to chantier material forms
- add fournisseur dropdown lists and sync scripts

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685964e93a888327b66a952c3e4a3e96