### PR TITLE
Update material forms

### DIFF
--- a/views/chantier/ajouterMateriel.ejs
+++ b/views/chantier/ajouterMateriel.ejs
@@ -164,13 +164,31 @@ select#emplacementId.form-control {
 <body>
   <div class="container mt-4">
     <h2>Ajouter du Matériel dans un Chantier</h2>
-    <form action="/chantier/ajouterMateriel" method="POST" enctype="multipart/form-data">
+    <form id="ajoutForm" action="/chantier/ajouterMateriel" method="POST" enctype="multipart/form-data">
       <div class="mb-3">
-        <label for="nom" class="form-label">Désignation</label>
-        <input type="text" name="nom" id="nom" class="form-control">
-        <select id="designationSelect" class="form-select mt-2">
+        <label for="categorie" class="form-label">Catégorie</label>
+        <select name="categorie" id="categorie" class="form-control" required>
+            <option value="AGENCEMENT">AGENCEMENT</option>
+            <option value="CVC">CVC</option>
+            <option value="Conso">Conso</option>
+            <option value="MENUISERIE">MENUISERIE</option>
+            <option value="MENUISERIE EXT">MENUISERIE EXT</option>
+            <option value="MOBILIER">MOBILIER</option>
+            <option value="PEINTURE">PEINTURE</option>
+            <option value="PLÂTRERIE">PLÂTRERIE</option>
+            <option value="SOL">SOL</option>
+            <option value="ST">ST</option>
+            <option value="Stockage Déchets">Stockage Déchets</option>
+            <option value="plomberie">plomberie</option>
+            <option value="électricité">électricité</option>
+        </select>
+      </div>
+      <div class="mb-3">
+        <label for="designationSelect" class="form-label">Désignation</label>
+        <select id="designationSelect" name="designation" class="form-select">
           <option value="">-- Sélectionner une désignation --</option>
         </select>
+        <input type="text" name="nom" id="designationInput" class="form-control mt-2" placeholder="Autre désignation">
       </div>
       <div class="mb-3">
         <label for="reference" class="form-label">Référence</label>
@@ -217,24 +235,6 @@ select#emplacementId.form-control {
           <option value="Wurth">Wurth</option>
           <option value="pure-com">pure-com</option>
           <option value="Autre">Autre</option>
-        </select>
-      </div>
-      <div class="mb-3">
-        <label for="categorie" class="form-label">Catégorie</label>
-        <select name="categorie" id="categorie" class="form-control" required>
-            <option value="AGENCEMENT">AGENCEMENT</option>
-            <option value="CVC">CVC</option>
-            <option value="Conso">Conso</option>
-            <option value="MENUISERIE">MENUISERIE</option>
-            <option value="MENUISERIE EXT">MENUISERIE EXT</option>
-            <option value="MOBILIER">MOBILIER</option>
-            <option value="PEINTURE">PEINTURE</option>
-            <option value="PLÂTRERIE">PLÂTRERIE</option>
-            <option value="SOL">SOL</option>
-            <option value="ST">ST</option>
-            <option value="Stockage Déchets">Stockage Déchets</option>
-            <option value="plomberie">plomberie</option>
-            <option value="électricité">électricité</option>
         </select>
       </div>
       <div class="mb-3">
@@ -442,11 +442,13 @@ select#emplacementId.form-control {
 
     const categorySelect = document.getElementById('categorie');
     const designationSelect = document.getElementById('designationSelect');
-    const designationInput = document.getElementById('nom');
+    const designationInput = document.getElementById('designationInput');
 
     function updateDesignations() {
       const cat = categorySelect.value;
       designationSelect.innerHTML = '<option value="">-- Sélectionner une désignation --</option>';
+      designationSelect.value = '';
+      designationInput.value = '';
       if (designationMap[cat]) {
         designationMap[cat].forEach(d => {
           const opt = document.createElement('option');
@@ -465,6 +467,15 @@ select#emplacementId.form-control {
     if (designationSelect) {
       designationSelect.addEventListener('change', () => {
         designationInput.value = designationSelect.value;
+      });
+    }
+
+    const form = document.getElementById('ajoutForm');
+    if (form) {
+      form.addEventListener('submit', () => {
+        if (designationSelect.value) {
+          designationInput.value = designationSelect.value;
+        }
       });
     }
   </script>

--- a/views/chantier/modifierMaterielChantier.ejs
+++ b/views/chantier/modifierMaterielChantier.ejs
@@ -10,27 +10,7 @@
 <body>
   <div class="container mt-3">
     <h2>Modifier l'enregistrement pour <%= mc.materiel.nom %> dans le chantier <%= mc.chantier.nom %></h2>
-    <form action="/chantier/materielChantier/modifier/<%= mc.id %>" method="POST" enctype="multipart/form-data">
-
-      <div class="mb-3">
-        <label for="quantite" class="form-label">Quantité actuelle : <strong><%= mc.quantite %></strong></label>
-      </div>
-
-      <div class="mb-3">
-        <label for="quantite" class="form-label">Nouvelle quantité</label>
-        <div class="d-flex align-items-center gap-2">
-          <button type="button" class="btn btn-outline-secondary" onclick="changerQuantite(-1)">-</button>
-          <input type="number" name="quantite" id="quantite" class="form-control" value="<%= mc.quantite %>" min="0" required>
-          <button type="button" class="btn btn-outline-secondary" onclick="changerQuantite(1)">+</button>
-        </div>
-      </div>
-
-      <div class="mb-3">
-        <label for="nomMateriel" class="form-label">Désignation</label>
-        <input type="text" class="form-control" id="nomMateriel" name="nomMateriel" value="<%= mc.materiel.nom %>">
-        <select id="designationSelect" class="form-select mt-2">
-          <option value="">-- Sélectionner une désignation --</option>
-        </select>
+    <form id="modifForm" action="/chantier/materielChantier/modifier/<%= mc.id %>" method="POST" enctype="multipart/form-data">
 
       <div class="mb-3">
   <label for="categorie" class="form-label">Catégorie</label>
@@ -52,7 +32,26 @@
   </select>
 </div>
 
+      <div class="mb-3">
+        <label for="quantite" class="form-label">Quantité actuelle : <strong><%= mc.quantite %></strong></label>
+      </div>
 
+      <div class="mb-3">
+        <label for="quantite" class="form-label">Nouvelle quantité</label>
+        <div class="d-flex align-items-center gap-2">
+          <button type="button" class="btn btn-outline-secondary" onclick="changerQuantite(-1)">-</button>
+          <input type="number" name="quantite" id="quantite" class="form-control" value="<%= mc.quantite %>" min="0" required>
+          <button type="button" class="btn btn-outline-secondary" onclick="changerQuantite(1)">+</button>
+        </div>
+      </div>
+
+      <div class="mb-3">
+  <label for="designationSelect" class="form-label">Désignation</label>
+  <select id="designationSelect" name="designation" class="form-select">
+    <option value="">-- Sélectionner une désignation --</option>
+  </select>
+  <input type="text" class="form-control mt-2" id="nomMateriel" name="nomMateriel" value="<%= mc.materiel.nom %>" placeholder="Autre désignation">
+</div>
       <div class="mb-3">
         <label for="emplacementId" class="form-label">Nouvel emplacement</label>
         <select name="emplacementId" id="emplacementId" class="form-control">
@@ -322,6 +321,8 @@
     function updateDesignations() {
       const cat = categorySelect.value;
       dSelect.innerHTML = '<option value="">-- Sélectionner une désignation --</option>';
+      dSelect.value = '';
+      dInput.value = '';
       if (designationMap[cat]) {
         designationMap[cat].forEach(d => {
           const opt = document.createElement('option');
@@ -340,6 +341,15 @@
     if (dSelect) {
       dSelect.addEventListener('change', () => {
         dInput.value = dSelect.value;
+      });
+    }
+
+    const form = document.getElementById('modifForm');
+    if (form) {
+      form.addEventListener('submit', () => {
+        if (dSelect.value) {
+          dInput.value = dSelect.value;
+        }
       });
     }
   </script>


### PR DESCRIPTION
## Summary
- reorder form fields so category is first
- link designation list to selected category
- add manual designation input
- sync manual input with dropdown on submit

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859705282688327bf49fee822aa464e