### PR TITLE
Fix required fields when editing chantier materials

### DIFF
--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -397,6 +397,13 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
       rack, compartiment, niveau
     } = req.body;
 
+    if (
+      !quantite || isNaN(parseInt(quantite, 10)) || parseInt(quantite, 10) < 0 ||
+      !nomMateriel || !nomMateriel.trim() || !categorie
+    ) {
+      return res.status(400).send("Les champs quantité, désignation et catégorie sont obligatoires.");
+    }
+
     const mc = await MaterielChantier.findByPk(req.params.id, {
       include: [
         { model: Materiel, as: 'materiel' },


### PR DESCRIPTION
## Summary
- enforce required fields when updating chantier materials

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a4f999b3c8327aa97db17cdbc4efe