### PR TITLE
Split fournisseur column in chantier stock table

### DIFF
--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -180,7 +180,8 @@
 
           <th>Référence</th>
           <th>Categorie</th>
-          <th>Description / Fournisseur</th>
+          <th>Description</th>
+          <th>Fournisseur</th>
           <th>Emplacement</th>
           <th>Rack</th>
           <th>Compartiment</th>
@@ -253,8 +254,12 @@
                 <% } else { %>
                   -
                 <% } %>
+              </td>
+              <td>
                 <% if(mc.materiel && mc.materiel.fournisseur) { %>
-                  <br><small class="text-muted">Fournisseur: <%= mc.materiel.fournisseur %></small>
+                  <%= mc.materiel.fournisseur %>
+                <% } else { %>
+                  -
                 <% } %>
               </td>
 
@@ -330,7 +335,7 @@
           <% }); %>
         <% } else { %>
           <tr>
-            <td colspan="5" class="text-center">Aucune livraison enregistrée pour les chantiers.</td>
+            <td colspan="13" class="text-center">Aucune livraison enregistrée pour les chantiers.</td>
           </tr>
         <% } %>
       </tbody>


### PR DESCRIPTION
## Summary
- add a dedicated column for `Fournisseur`
- show only description in the description column
- display fournisseur data in its own cell
- update message row colspan

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a53d6116c8327b8ab65f3d0595575