### PR TITLE
Fix affichage photo materiel chantier

### DIFF
--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -210,10 +210,10 @@
                 <% } %>
               </td>
                 <td>
-                <% if (mc.materiel.photos && mc.materiel.photos.length > 0) { %>
-                  <img src="/<%= mc.materiel.photos[0].chemin.replace(/\\/g, '/') %>" alt="Photo"
-                      width="80" style="cursor: pointer;"
-                      data-bs-toggle="modal" data-bs-target="#photoModal<%= mc.id %>">
+                <% if (mc.materiel && mc.materiel.photo) { %>
+                  <img src="/uploads/<%= mc.materiel.photo %>" alt="Photo"
+                       width="80" style="cursor: pointer;"
+                       data-bs-toggle="modal" data-bs-target="#photoModal<%= mc.id %>">
 
                   <!-- Modale pour agrandir la photo -->
                   <div class="modal fade" id="photoModal<%= mc.id %>" tabindex="-1" aria-labelledby="photoModalLabel<%= mc.id %>" aria-hidden="true">
@@ -224,13 +224,11 @@
                           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
                         </div>
                         <div class="modal-body text-center">
-                          <img src="/<%= mc.materiel.photos[0].chemin.replace(/\\/g, '/') %>" alt="Photo grand format" class="img-fluid rounded">
+                          <img src="/uploads/<%= mc.materiel.photo %>" alt="Photo grand format" class="img-fluid rounded">
                         </div>
                       </div>
                     </div>
                   </div>
-                <% } else { %>
-                  -
                 <% } %>
               </td>
 


### PR DESCRIPTION
## Summary
- ajuste la vue `chantier/index.ejs` pour afficher la photo simple `mc.materiel.photo`
- ouvre l'image en modal grand format

## Testing
- `npm start` *(fails: missing server start due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_685a5a236ba483279f6c7b09405197ed