### PR TITLE
Fix photo display in chantier table

### DIFF
--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -209,25 +209,12 @@
                   N/A
                 <% } %>
               </td>
-                <td>
+              <td>
                 <% if (mc.materiel && mc.materiel.photo) { %>
-                  <img
-                    src="/uploads/<%= mc.materiel.photo %>"
-                    alt="Photo de <%= mc.materiel.nom %>"
-                    width="80"
-                    style="cursor: pointer;"
-                    data-bs-toggle="modal"
-                    data-bs-target="#photoModal<%= mc.id %>"
-                  >
-
-                  <!-- Modale pour agrandir la photo -->
-                  <div
-                    class="modal fade"
-                    id="photoModal<%= mc.id %>"
-                    tabindex="-1"
-                    aria-labelledby="photoModalLabel<%= mc.id %>"
-                    aria-hidden="true"
-                  >
+                  <img src="/uploads/<%= mc.materiel.photo %>" width="80" alt="Photo de <%= mc.materiel.nom %>"
+                       style="cursor: pointer;" data-bs-toggle="modal" data-bs-target="#photoModal<%= mc.id %>">
+                  <!-- Modale -->
+                  <div class="modal fade" id="photoModal<%= mc.id %>" tabindex="-1" aria-labelledby="photoModalLabel<%= mc.id %>" aria-hidden="true">
                     <div class="modal-dialog modal-dialog-centered modal-lg">
                       <div class="modal-content">
                         <div class="modal-header">
@@ -235,15 +222,13 @@
                           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
                         </div>
                         <div class="modal-body text-center">
-                          <img
-                            src="/uploads/<%= mc.materiel.photo %>"
-                            alt="Photo de <%= mc.materiel.nom %>"
-                            class="img-fluid rounded"
-                          >
+                          <img src="/uploads/<%= mc.materiel.photo %>" alt="Photo grand format" class="img-fluid rounded">
                         </div>
                       </div>
                     </div>
                   </div>
+                <% } else { %>
+                  N/A
                 <% } %>
               </td>
 


### PR DESCRIPTION
## Summary
- show material photo inside table cell
- add bootstrap modal to enlarge photo or show placeholder

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a63006748832798ed187b6de7aef6