### PR TITLE
Handle missing photo path on update

### DIFF
--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -456,10 +456,15 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
     });
 
     // Photo
+    console.log(req.file);
     if (req.file) {
+      const chemin = req.file.path || req.file.secure_url;
+      if (!chemin) {
+        return res.send("Erreur photo...");
+      }
       await Photo.destroy({ where: { materielId: mc.materiel.id } });
       await Photo.create({
-        chemin: req.file.path,
+        chemin,
         materielId: mc.materiel.id
       });
     }
@@ -532,9 +537,14 @@ router.post('/materielChantier/dupliquer/:id', ensureAuthenticated, checkAdmin, 
     });
 
     // Gérer la photo si fournie
+    console.log(req.file);
     if (req.file) {
+      const chemin = req.file.path || req.file.secure_url;
+      if (!chemin) {
+        return res.send("Erreur photo...");
+      }
       await Photo.create({
-        chemin: req.file.path,
+        chemin,
         materielId: nouveauMateriel.id
       });
     }


### PR DESCRIPTION
## Summary
- avoid crash when modifying chantier material without `req.file.path`
- log `req.file` for debugging
- use `req.file.path || req.file.secure_url`
- keep old photo cleanup logic and send clear error message if no photo path

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a9d557a808327a3313c77c2cd1f5e