### PR TITLE
Add categories for chantier stock

### DIFF
--- a/views/chantier/ajouterMateriel.ejs
+++ b/views/chantier/ajouterMateriel.ejs
@@ -175,6 +175,7 @@ select#emplacementId.form-control {
             <option value="menuiserie ext">MENUISERIE EXT</option>
             <option value="mobilier">MOBILIER</option>
             <option value="peinture">PEINTURE</option>
+            <option value="revetement mural">REVÊTEMENT MURAL</option>
             <option value="platrerie">PLÂTRERIE</option>
             <option value="sol">SOL</option>
             <option value="st">ST</option>

--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -135,6 +135,7 @@
     <option value="Maçonnerie" <%= categorie === 'Maçonnerie' ? 'selected' : '' %>>Maçonnerie</option>
     <option value="Menuiserie" <%= categorie === 'Menuiserie' ? 'selected' : '' %>>Menuiserie</option>
       <option value="Mobilier" <%= categorie === 'Mobilier' ? 'selected' : '' %>>Mobilier</option>
+    <option value="Peinture" <%= categorie === 'Peinture' ? 'selected' : '' %>>Peinture</option>
     <option value="Agencement" <%= categorie === 'Agencement' ? 'selected' : '' %>>Agencement</option>
     <option value="Fixation/Visserie" <%= categorie === 'Fixation/Visserie' ? 'selected' : '' %>>Fixation/Visserie</option>
  


### PR DESCRIPTION
## Summary
- include "REVÊTEMENT MURAL" option when adding matériel to a chantier
- add "Peinture" category for chantier inventory filtering

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685bb822fea08327903bd38c9d3c06ba