### PR TITLE
Update Cloudinary config and dotenv order

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
-// app.js
 require('dotenv').config();
+// app.js
 
 const express       = require('express');
 const crypto        = require('crypto');

--- a/config/cloudinary.config.js
+++ b/config/cloudinary.config.js
@@ -1,16 +1,20 @@
+// config/cloudinary.config.js 
+
+// Charge les variables d’environnement avant tout usage
 require('dotenv').config();
-const cloudinary = require('cloudinary').v2;
+
+const { v2: cloudinary } = require('cloudinary');
 const { CloudinaryStorage } = require('multer-storage-cloudinary');
 
 cloudinary.config({
   cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
-  api_key: process.env.CLOUDINARY_API_KEY,
-  api_secret: process.env.CLOUDINARY_API_SECRET,
+  api_key:    process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET
 });
 
 const storage = new CloudinaryStorage({
   cloudinary,
-  params: { folder: 'gestion-stock' },
+  params: { folder: 'gestion-stock' }
 });
 
 module.exports = { cloudinary, storage };


### PR DESCRIPTION
## Summary
- update `config/cloudinary.config.js` with new configuration snippet
- ensure `app.js` starts with `require('dotenv').config();`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685be25295f083278984ba2e6f132ee2