### PR TITLE
Fix case-insensitive category filter

### DIFF
--- a/routes/materiel.js
+++ b/routes/materiel.js
@@ -3,7 +3,7 @@ const express = require('express');
 const router = express.Router();
 const multer = require('multer');
 const { storage, cloudinary } = require('../config/cloudinary.config');
-const { Op } = require('sequelize');
+const { Op, fn, col, where } = require('sequelize');
 const ExcelJS = require('exceljs');
 const PDFDocument = require('pdfkit');
 
@@ -198,7 +198,10 @@ router.get('/', ensureAuthenticated, async (req, res) => {
       whereClause.reference = { [Op.like]: `%${reference}%` };
     }
     if (categorie && categorie.trim() !== '') {
-      whereClause.categorie = categorie;
+      whereClause.categorie = where(
+        fn('LOWER', col('categorie')),
+        { [Op.like]: `%${categorie.toLowerCase()}%` }
+      );
     }
     if (rack && rack.trim() !== '') {
       whereClause.rack = rack;


### PR DESCRIPTION
## Summary
- make depot materials category filtering case-insensitive

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685cf313651c8327bcb4f781ac76fd7f