### PR TITLE
Add navigation buttons block

### DIFF
--- a/views/bonLivraison/index.ejs
+++ b/views/bonLivraison/index.ejs
@@ -68,6 +68,10 @@
       </a>
     </div>
   </nav>
+<div style="display:flex;gap:10px;margin-top:10px;">
+  <button onclick="location.href='https://receptionbr.onrender.com/selection.html'">Gestion Tâches</button>
+  <button onclick="location.href='https://receptionbr.onrender.com/'">Réception</button>
+</div>
 
   <!-- Contenu principal -->
   <div class="container my-4">

--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -57,6 +57,10 @@
       <button id="toggleMode" class="btn btn-outline-secondary">Mode sombre</button>
     </div>
   </nav>
+<div style="display:flex;gap:10px;margin-top:10px;">
+  <button onclick="location.href='https://receptionbr.onrender.com/selection.html'">Gestion Tâches</button>
+  <button onclick="location.href='https://receptionbr.onrender.com/'">Réception</button>
+</div>
   
   
 

--- a/views/emplacements/index.ejs
+++ b/views/emplacements/index.ejs
@@ -6,6 +6,10 @@
   <link rel="stylesheet" href="/css/bootstrap.min.css">
 </head>
 <body>
+<div style='display:flex;gap:10px;margin-top:10px;'>
+  <button onclick='location.href="https://receptionbr.onrender.com/selection.html"'>Gestion Tâches</button>
+  <button onclick='location.href="https://receptionbr.onrender.com/"'>Réception</button>
+</div>
   <div class="container mt-4">
     <h1>Emplacements</h1>
     <form class="row g-2 mb-3" method="GET" action="/emplacements">

--- a/views/materiel/dashboard.ejs
+++ b/views/materiel/dashboard.ejs
@@ -110,6 +110,10 @@
       </div>
     </div>
   </nav>
+<div style="display:flex;gap:10px;margin-top:10px;">
+  <button onclick="location.href='https://receptionbr.onrender.com/selection.html'">Gestion Tâches</button>
+  <button onclick="location.href='https://receptionbr.onrender.com/'">Réception</button>
+</div>
 
   <!-- Contenu principal -->
   <div class="container mt-4">

--- a/views/vehicule/dashboard.ejs
+++ b/views/vehicule/dashboard.ejs
@@ -13,6 +13,10 @@
       <button id="toggleMode" class="btn btn-secondary">Mode sombre</button>
     </div>
   </nav>
+<div style="display:flex;gap:10px;margin-top:10px;">
+  <button onclick="location.href='https://receptionbr.onrender.com/selection.html'">Gestion Tâches</button>
+  <button onclick="location.href='https://receptionbr.onrender.com/'">Réception</button>
+</div>
 
   <div class="container mt-3">
     <form class="row g-3 mb-3" method="GET" action="/vehicule">


### PR DESCRIPTION
## Summary
- add quick navigation button block at top of several dashboards

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686242aa337083279118d73d2869e84c