### PR TITLE
Add proxy usage for chantier images

### DIFF
--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -217,7 +217,9 @@
               </td>
               <td>
                 <% if (mc.materiel && mc.materiel.photos && mc.materiel.photos.length > 0) { %>
-                  <% const publicId = mc.materiel.photos[0].chemin.split('/').pop().split('.')[0]; %>
+                  <% const publicId = mc.materiel.photos[0].chemin
+                    .replace(/^https?:\/\/res\.cloudinary\.com\/[^/]+\/image\/upload\//, '')
+                    .replace(/\.[^.]+$/, ''); %>
                   <img 
                     src="/img-proxy/<%= publicId %>" 
                     width="80" 


### PR DESCRIPTION
## Summary
- fetch Cloudinary publicId by stripping URL prefix and extension
- use `/img-proxy/:public_id` route when displaying chantier photos

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_68624e355da88327932f19d93f05e44b