### PR TITLE
Add Cloudinary image proxy

### DIFF
--- a/app.js
+++ b/app.js
@@ -81,12 +81,15 @@ sequelize.sync({ alter: true })
 
 app.get('/img-proxy/:public_id', async (req, res, next) => {
   try {
-    const url = `https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/image/upload/${req.params.public_id}`;
-    const resp = await fetch(url);
-    if (!resp.ok) return res.sendStatus(resp.status);
-    const buffer = await resp.arrayBuffer();
-    res.setHeader('Content-Type', resp.headers.get('Content-Type'));
+    const publicId = req.params.public_id;
+    const url = `https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/image/upload/${publicId}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      return res.sendStatus(response.status);
+    }
+    res.setHeader('Content-Type', response.headers.get('Content-Type'));
     res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
+    const buffer = await response.arrayBuffer();
     res.send(Buffer.from(buffer));
   } catch (err) {
     next(err);

--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -217,12 +217,13 @@
               </td>
               <td>
                 <% if (mc.materiel && mc.materiel.photos && mc.materiel.photos.length > 0) { %>
-                  <% const publicId = mc.materiel.photos[0].chemin
-                    .replace(/^https?:\/\/res\.cloudinary\.com\/[^/]+\/image\/upload\//, '')
-                    .replace(/\.[^.]+$/, ''); %>
-                  <img 
-                    src="/img-proxy/<%= publicId %>" 
-                    width="80" 
+                  <% const photoUrl = mc.materiel.photos[0].chemin;
+                     const publicId = photoUrl
+                      .replace(/^https?:\/\/res\.cloudinary\.com\/[^/]+\/image\/upload\//, '')
+                      .replace(/\.[^.]+$/, ''); %>
+                  <img
+                    src="/img-proxy/<%= publicId %>"
+                    width="80"
                     alt="Photo de <%= mc.materiel.nom %>"
                     style="cursor: pointer;" data-bs-toggle="modal" data-bs-target="#photoModal<%= mc.id %>">
                   <!-- Modale -->


### PR DESCRIPTION
## Summary
- proxy Cloudinary images through `/img-proxy/:public_id`
- compute publicId in chantier listing and use new proxy route

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68624fff5c6c83278a36cd6498583afb