### PR TITLE
Improve /chantier text filters

### DIFF
--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -2,7 +2,7 @@
 const Emplacement = require('../models/Emplacement');
 const express = require('express');
 const router = express.Router();
-const { Op, fn, col, where } = require('sequelize');
+const { Op } = require('sequelize');
 const multer = require('multer');
 const { storage, cloudinary } = require('../config/cloudinary.config');
 
@@ -26,18 +26,15 @@ router.get('/', ensureAuthenticated, async (req, res) => {
     const whereChantier = chantierId ? { chantierId: chantierId } : {};
     const whereMateriel = {};
 
-    if (nomMateriel) {
-      whereMateriel.nom = { [Op.like]: `%${nomMateriel}%` };
-    }
-    if (categorie) {
-      whereMateriel.categorie = where(
-        fn('LOWER', col('categorie')),
-        { [Op.like]: `%${categorie.toLowerCase()}%` }
-      );
-    }
-    if (description) {
-      whereMateriel.description = { [Op.like]: `%${description}%` };
-    }
+  if (nomMateriel) {
+    whereMateriel.nom = { [Op.iLike]: `%${nomMateriel}%` };
+  }
+  if (categorie) {
+    whereMateriel.categorie = { [Op.iLike]: `%${categorie}%` };
+  }
+  if (description) {
+    whereMateriel.description = { [Op.iLike]: `%${description}%` };
+  }
 
 
     const order = [];
@@ -66,9 +63,9 @@ router.get('/', ensureAuthenticated, async (req, res) => {
        {
   model: Emplacement,
   as: 'emplacement',
-  where: emplacement
-    ? { nom: { [Op.like]: `%${emplacement}%` } }
-    : undefined,
+    where: emplacement
+      ? { nom: { [Op.iLike]: `%${emplacement}%` } }
+      : undefined,
   include: [
     {
       model: Emplacement,


### PR DESCRIPTION
## Summary
- import `Op` from Sequelize only
- use `Op.iLike` for case-insensitive filtering on `/chantier` search fields

## Testing
- `npm start` *(fails: Please install sqlite3 package manually)*

------
https://chatgpt.com/codex/tasks/task_e_68625721d9588327947731513745e8f4