### PR TITLE
Allow editing reference on chantier stock

### DIFF
--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -392,7 +392,7 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
   try {
     const {
       quantite, nomMateriel, categorie, fournisseur, emplacementId,
-      rack, compartiment, niveau
+      rack, compartiment, niveau, reference
     } = req.body;
 
     if (
@@ -420,6 +420,7 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
     const oldCompartiment = mc.materiel.compartiment;
     const oldFournisseur = mc.materiel.fournisseur;
     const oldNiveau = mc.materiel.niveau;
+    const oldReference = mc.materiel.reference;
 
     const newQte = parseInt(quantite, 10);
     const newNom = nomMateriel.trim();
@@ -429,6 +430,7 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
     const newCompartiment = compartiment;
     const newFournisseur = fournisseur;
     const newNiveau = niveau ? parseInt(niveau) : null;
+    const newReference = reference;
 
     if (oldQte !== newQte) changementsDetail.push(`Quantité: ${oldQte} ➔ ${newQte}`);
     if (oldNom !== newNom) changementsDetail.push(`Nom: ${oldNom} ➔ ${newNom}`);
@@ -438,6 +440,7 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
     if (oldFournisseur !== newFournisseur) changementsDetail.push(`Fournisseur: ${oldFournisseur || '-'} ➔ ${newFournisseur || '-'}`);
     if (oldCompartiment !== newCompartiment) changementsDetail.push(`Compartiment: ${oldCompartiment || '-'} ➔ ${newCompartiment || '-'}`);
     if (oldNiveau !== newNiveau) changementsDetail.push(`Niveau: ${oldNiveau || '-'} ➔ ${newNiveau || '-'}`);
+    if (oldReference !== newReference) changementsDetail.push(`Référence: ${oldReference || '-'} ➔ ${newReference || '-'}`);
 
     // Mise à jour
     mc.quantite = newQte;
@@ -448,6 +451,7 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
     mc.materiel.rack = newRack;
     mc.materiel.compartiment = newCompartiment;
     mc.materiel.niveau = newNiveau;
+    mc.materiel.reference = newReference;
 
     await mc.materiel.save();
     await mc.save();

--- a/views/chantier/modifierMaterielChantier.ejs
+++ b/views/chantier/modifierMaterielChantier.ejs
@@ -56,6 +56,10 @@
   <input type="text" class="form-control mt-2" id="nomMateriel" name="nomMateriel" value="<%= mc.materiel.nom %>" placeholder="Autre désignation">
 </div>
       <div class="mb-3">
+        <label for="reference" class="form-label">Référence</label>
+        <input type="text" name="reference" id="reference" class="form-control" value="<%= mc.materiel.reference || '' %>">
+      </div>
+      <div class="mb-3">
         <label for="emplacementId" class="form-label">Nouvel emplacement</label>
         <select name="emplacementId" id="emplacementId" class="form-control">
           <option value="">-- Aucun --</option>


### PR DESCRIPTION
## Summary
- enable reference field editing when updating a chantier stock item
- show reference in modification form

## Testing
- `npm start` *(fails: no tests provided)*

------
https://chatgpt.com/codex/tasks/task_e_68625cd9af748327a19b45c95d0fe6b5