### PR TITLE
Update img proxy path handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -83,8 +83,8 @@ sequelize.sync({ alter: true })
 
 // Proxy pour récupérer les images Cloudinary avec les bons headers
 
-app.get('/img-proxy/:public_id', (req, res, next) => {
-  const publicId = req.params.public_id;
+app.get('/img-proxy/*', (req, res, next) => {
+  const publicId = req.params[0];
   const url = `https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/image/upload/${publicId}`;
 
   https.get(url, response => {

--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -217,11 +217,14 @@
               </td>
               <td>
                 <% if (mc.materiel && mc.materiel.photos && mc.materiel.photos.length > 0) { %>
-                  <% const publicId = mc.materiel.photos[0].chemin
-                      .replace(/^https?:\/\/res\.cloudinary\.com\/[^/]+\/image\/upload\//, '')
-                      .replace(/\.[^.]+$/, ''); %>
+                  <% const fullPath = mc.materiel.photos[0].chemin
+                       .replace(
+                         `https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/image/upload/`,
+                         ''
+                       );
+                  %>
                   <img
-                    src="/img-proxy/<%= publicId %>"
+                    src="/img-proxy/<%= fullPath %>"
                     width="80"
                     alt="Photo de <%= mc.materiel.nom %>"
                     style="cursor: pointer;" data-bs-toggle="modal" data-bs-target="#photoModal<%= mc.id %>">
@@ -234,7 +237,7 @@
                           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
                         </div>
                         <div class="modal-body text-center">
-                          <img src="/img-proxy/<%= publicId %>" alt="Photo de <%= mc.materiel.nom %>" class="img-fluid rounded">
+                          <img src="/img-proxy/<%= fullPath %>" alt="Photo de <%= mc.materiel.nom %>" class="img-fluid rounded">
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- support wildcard path for image proxy
- keep full Cloudinary file path for chantier images

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862655131c88327b356e9b1db5a48fc