### PR TITLE
Fix chantier category naming

### DIFF
--- a/public/js/designations.js
+++ b/public/js/designations.js
@@ -116,7 +116,7 @@
       "Pot balai court à poser Référence:274 00",
       "PACK BATI SUPPORT COMPLET Geberit + cuvette Renova Compact 203245000"
     ],
-    electricite: [
+    electricité: [
       "INTERRUPTEUR A BADGE - CM0010 complet",
       "Interrupteur double Surface Céliane blanc compris : boite d'encastrement simple, support, interrupteur double, enjoliveur & plaque finition",
       "Interrupteur simple Surface Céliane blanc compris : boite d'encastrement, support, interrupteur, enjoliveur & plaque finition",

--- a/views/chantier/ajouterMateriel.ejs
+++ b/views/chantier/ajouterMateriel.ejs
@@ -181,7 +181,7 @@ select#emplacementId.form-control {
             <option value="st">ST</option>
             <option value="stockage dechets">Stockage Déchets</option>
             <option value="plomberie">plomberie</option>
-            <option value="electricite">ÉLECTRICITÉ</option>
+            <option value="Electricité">ÉLECTRICITÉ</option>
             <option value="climatisation">CLIMATISATION</option>
         </select>
       </div>

--- a/views/chantier/modifierMaterielChantier.ejs
+++ b/views/chantier/modifierMaterielChantier.ejs
@@ -30,7 +30,7 @@
     <option value="st" <%= currentCat === 'st' ? 'selected' : '' %>>ST</option>
     <option value="stockage dechets" <%= currentCat === 'stockage dechets' ? 'selected' : '' %>>Stockage Déchets</option>
     <option value="plomberie" <%= currentCat === 'plomberie' ? 'selected' : '' %>>plomberie</option>
-    <option value="electricite" <%= currentCat === 'electricite' || currentCat === 'électricité' ? 'selected' : '' %>>ÉLECTRICITÉ</option>
+    <option value="Electricité" <%= currentCat === 'electricite' || currentCat === 'électricité' ? 'selected' : '' %>>ÉLECTRICITÉ</option>
     <option value="climatisation" <%= currentCat === 'climatisation' ? 'selected' : '' %>>CLIMATISATION</option>
   </select>
 </div>


### PR DESCRIPTION
## Summary
- change "electricite" option to "Electricité" for chantier
- align designation mapping with new category name

## Testing
- `node app.js` *(fails: Please install sqlite3 package manually)*

------
https://chatgpt.com/codex/tasks/task_e_6863b34a5c0c8327b504dab90d180306