### PR TITLE
Fix Electricité option selection

### DIFF
--- a/views/chantier/modifierMaterielChantier.ejs
+++ b/views/chantier/modifierMaterielChantier.ejs
@@ -30,7 +30,10 @@
     <option value="st" <%= currentCat === 'st' ? 'selected' : '' %>>ST</option>
     <option value="stockage dechets" <%= currentCat === 'stockage dechets' ? 'selected' : '' %>>Stockage Déchets</option>
     <option value="plomberie" <%= currentCat === 'plomberie' ? 'selected' : '' %>>plomberie</option>
-    <option value="Electricité" <%= currentCat === 'electricite' || currentCat === 'électricité' ? 'selected' : '' %>>ÉLECTRICITÉ</option>
+    <option value="Electricité"
+      <%= ['electricite', 'électricité', 'electricité'].includes(currentCat) ? 'selected' : '' %>>
+        ÉLECTRICITÉ
+    </option>
     <option value="climatisation" <%= currentCat === 'climatisation' ? 'selected' : '' %>>CLIMATISATION</option>
   </select>
 </div>


### PR DESCRIPTION
## Summary
- ensure the "ÉLECTRICITÉ" option is preselected regardless of accent differences in stored category

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686540d9e8e0832782ca257df8485e63