### PR TITLE
Add wall/floor covering category to chantier edit form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/views/chantier/modifierMaterielChantier.ejs
+++ b/views/chantier/modifierMaterielChantier.ejs
@@ -25,6 +25,7 @@
     <option value="menuiserie ext" <%= currentCat === 'menuiserie ext' ? 'selected' : '' %>>MENUISERIE EXT</option>
     <option value="mobilier" <%= currentCat === 'mobilier' ? 'selected' : '' %>>MOBILIER</option>
     <option value="peinture" <%= currentCat === 'peinture' ? 'selected' : '' %>>PEINTURE</option>
+    <option value="revetement mural / revetement sol" <%= currentCat === 'revetement mural / revetement sol' ? 'selected' : '' %>>REVÊTEMENT MURAL / REVÊTEMENT SOL</option>
     <option value="platrerie" <%= currentCat === 'platrerie' ? 'selected' : '' %>>PLÂTRERIE</option>
     <option value="sol" <%= currentCat === 'sol' ? 'selected' : '' %>>SOL</option>
     <option value="st" <%= currentCat === 'st' ? 'selected' : '' %>>ST</option>


### PR DESCRIPTION
## Summary
- add the missing "Revêtement mural / Revêtement Sol" category to the chantier material edit dropdown
- ignore node_modules with .gitignore

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b9a1c7c3d4832888125e9f05bfa0d6