### PR TITLE
Permet la modification de la description d'un matériel de chantier

### DIFF
--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -392,7 +392,7 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
   try {
     const {
       quantite, nomMateriel, categorie, fournisseur, emplacementId,
-      rack, compartiment, niveau, reference
+      rack, compartiment, niveau, reference, description
     } = req.body;
 
     if (
@@ -421,6 +421,7 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
     const oldFournisseur = mc.materiel.fournisseur;
     const oldNiveau = mc.materiel.niveau;
     const oldReference = mc.materiel.reference;
+    const oldDescription = mc.materiel.description;
 
     const newQte = parseInt(quantite, 10);
     const newNom = nomMateriel.trim();
@@ -431,6 +432,7 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
     const newFournisseur = fournisseur;
     const newNiveau = niveau ? parseInt(niveau) : null;
     const newReference = reference;
+    const newDescription = description;
 
     if (oldQte !== newQte) changementsDetail.push(`Quantité: ${oldQte} ➔ ${newQte}`);
     if (oldNom !== newNom) changementsDetail.push(`Nom: ${oldNom} ➔ ${newNom}`);
@@ -441,6 +443,7 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
     if (oldCompartiment !== newCompartiment) changementsDetail.push(`Compartiment: ${oldCompartiment || '-'} ➔ ${newCompartiment || '-'}`);
     if (oldNiveau !== newNiveau) changementsDetail.push(`Niveau: ${oldNiveau || '-'} ➔ ${newNiveau || '-'}`);
     if (oldReference !== newReference) changementsDetail.push(`Référence: ${oldReference || '-'} ➔ ${newReference || '-'}`);
+    if (oldDescription !== newDescription) changementsDetail.push(`Description: ${oldDescription || '-'} ➔ ${newDescription || '-'}`);
 
     // Mise à jour
     mc.quantite = newQte;
@@ -452,6 +455,7 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
     mc.materiel.compartiment = newCompartiment;
     mc.materiel.niveau = newNiveau;
     mc.materiel.reference = newReference;
+    mc.materiel.description = newDescription;
 
     await mc.materiel.save();
     await mc.save();

--- a/views/chantier/modifierMaterielChantier.ejs
+++ b/views/chantier/modifierMaterielChantier.ejs
@@ -64,6 +64,10 @@
         <input type="text" name="reference" id="reference" class="form-control" value="<%= mc.materiel.reference || '' %>">
       </div>
       <div class="mb-3">
+        <label for="description" class="form-label">Description</label>
+        <textarea name="description" id="description" class="form-control"><%= mc.materiel.description || '' %></textarea>
+      </div>
+      <div class="mb-3">
         <label for="emplacementId" class="form-label">Nouvel emplacement</label>
         <select name="emplacementId" id="emplacementId" class="form-control">
           <option value="">-- Aucun --</option>


### PR DESCRIPTION
## Résumé
- Ajout d'un champ de description dans le formulaire de modification du matériel de chantier
- Prise en compte de la description dans la route de mise à jour et l'historique des changements

## Tests
- `npm test` *(échoue : Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c7bec9a7148328a95a409c3ce5adb8