### PR TITLE
Quantité optionnelle lors de la modification d'un matériel chantier

### DIFF
--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -395,13 +395,6 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
       rack, compartiment, niveau, reference, description, prix
     } = req.body;
 
-    if (
-      !quantite || isNaN(parseInt(quantite, 10)) || parseInt(quantite, 10) < 0 ||
-      !nomMateriel || !nomMateriel.trim() || !categorie
-    ) {
-      return res.status(400).send("Les champs quantité, désignation et catégorie sont obligatoires.");
-    }
-
     const mc = await MaterielChantier.findByPk(req.params.id, {
       include: [
         { model: Materiel, as: 'materiel' },
@@ -409,6 +402,17 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
       ]
     });
     if (!mc) return res.send("Enregistrement non trouvé.");
+
+    const newQte = (quantite === undefined || quantite === '')
+      ? mc.quantite
+      : parseInt(quantite, 10);
+
+    if (
+      isNaN(newQte) || newQte < 0 ||
+      !nomMateriel || !nomMateriel.trim() || !categorie
+    ) {
+      return res.status(400).send("Les champs désignation et catégorie sont obligatoires.");
+    }
 
     const changementsDetail = [];
 
@@ -424,7 +428,6 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
     const oldDescription = mc.materiel.description;
     const oldPrix = mc.materiel.prix;
 
-    const newQte = parseInt(quantite, 10);
     const newNom = nomMateriel.trim();
     const newCategorie = categorie;
     const newEmplacement = emplacementId ? parseInt(emplacementId) : null;

--- a/views/chantier/modifierMaterielChantier.ejs
+++ b/views/chantier/modifierMaterielChantier.ejs
@@ -47,7 +47,7 @@
         <label for="quantite" class="form-label">Nouvelle quantité</label>
         <div class="d-flex align-items-center gap-2">
           <button type="button" class="btn btn-outline-secondary" onclick="changerQuantite(-1)">-</button>
-          <input type="number" name="quantite" id="quantite" class="form-control" value="<%= mc.quantite %>" min="0" required>
+          <input type="number" name="quantite" id="quantite" class="form-control" value="<%= mc.quantite %>" min="0">
           <button type="button" class="btn btn-outline-secondary" onclick="changerQuantite(1)">+</button>
         </div>
       </div>


### PR DESCRIPTION
## Résumé
- Autorise la modification d'un matériel de chantier sans renseigner la quantité
- Supprime l'obligation de saisir la quantité dans le formulaire côté client

## Test
- `npm test` *(échec: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c7cb7b35ec8328ae290b0a34b1a8c9