### PR TITLE
feat: allow admins to add custom categories

### DIFF
--- a/config/categories.json
+++ b/config/categories.json
@@ -1,0 +1,17 @@
+[
+  "agencement",
+  "cvc",
+  "conso",
+  "menuiserie",
+  "menuiserie ext",
+  "mobilier",
+  "peinture",
+  "revetement mural / revetement sol",
+  "platrerie",
+  "sol",
+  "st",
+  "stockage dechets",
+  "plomberie",
+  "Electricité",
+  "climatisation"
+]

--- a/views/chantier/ajouterMateriel.ejs
+++ b/views/chantier/ajouterMateriel.ejs
@@ -169,22 +169,13 @@ select#emplacementId.form-control {
         <label for="categorieSelect" class="form-label">Catégorie</label>
         <select name="categorie" id="categorieSelect" class="form-control" required>
             <option value="" disabled selected>-- Choisir Catégorie --</option>
-            <option value="agencement">AGENCEMENT</option>
-            <option value="cvc">CVC</option>
-            <option value="conso">Conso</option>
-            <option value="menuiserie">MENUISERIE</option>
-            <option value="menuiserie ext">MENUISERIE EXT</option>
-            <option value="mobilier">MOBILIER</option>
-            <option value="peinture">PEINTURE</option>
-            <option value="revetement mural / revetement sol">REVÊTEMENT MURAL / REVÊTEMENT SOL</option>
-            <option value="platrerie">PLÂTRERIE</option>
-            <option value="sol">SOL</option>
-            <option value="st">ST</option>
-            <option value="stockage dechets">Stockage Déchets</option>
-            <option value="plomberie">plomberie</option>
-            <option value="Electricité">ÉLECTRICITÉ</option>
-            <option value="climatisation">CLIMATISATION</option>
+            <% (categories || []).forEach(function(cat){ %>
+              <option value="<%= cat %>"><%= cat %></option>
+            <% }) %>
         </select>
+        <% if (user && user.role === 'admin') { %>
+          <button type="button" id="addCategoryBtn" class="btn btn-secondary btn-sm mt-2">Ajouter Catégorie</button>
+        <% } %>
       </div>
       <div class="mb-3">
         <label for="designationSelect" class="form-label">Désignation</label>
@@ -313,6 +304,30 @@ select#emplacementId.form-control {
             fournisseurSelect.value = val;
           });
         }
+      }
+      const addBtn = document.getElementById('addCategoryBtn');
+      if (addBtn) {
+        addBtn.addEventListener('click', async () => {
+          const nom = prompt('Nouvelle catégorie :');
+          if (!nom) return;
+          const body = new URLSearchParams();
+          body.append('nom', nom);
+          const resp = await fetch('/chantier/ajouter-categorie', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: body.toString()
+          });
+          if (resp.ok) {
+            const select = document.getElementById('categorieSelect');
+            const option = document.createElement('option');
+            option.value = nom;
+            option.textContent = nom;
+            select.appendChild(option);
+            select.value = nom;
+          } else {
+            alert("Erreur lors de l'ajout de la catégorie");
+          }
+        });
       }
       initDesignationDropdown('categorieSelect', 'designationSelect', 'designationInput');
       });

--- a/views/chantier/dupliquerMaterielChantier.ejs
+++ b/views/chantier/dupliquerMaterielChantier.ejs
@@ -62,16 +62,19 @@
       </div>
       <div class="mb-3">
         <label for="categorieSelect" class="form-label">Catégorie</label>
+        <% const cats = categories || []; %>
         <select name="categorie" id="categorieSelect" class="form-control" required>
-          <option value="Electricité">Electricité</option>
-          <option value="Plomberie">Plomberie</option>
-          <option value="Climatisation">Climatisation</option>
-          <option value="Chauffage">Chauffage</option>
-          <option value="Revêtement mural / Revêtement Sol">Revêtement mural / Revêtement Sol</option>
-          <option value="Maçonnerie">Maçonnerie</option>
-          <option value="Menuiserie">Menuiserie</option>
-          <option value="Autre">Autre</option>
+          <option value="" disabled>-- Choisir Catégorie --</option>
+          <% cats.forEach(function(cat){ %>
+            <option value="<%= cat %>" <%= mc.materiel.categorie === cat ? 'selected' : '' %>><%= cat %></option>
+          <% }) %>
+          <% if (mc.materiel.categorie && !cats.includes(mc.materiel.categorie)) { %>
+            <option value="<%= mc.materiel.categorie %>" selected><%= mc.materiel.categorie %></option>
+          <% } %>
         </select>
+        <% if (user && user.role === 'admin') { %>
+          <button type="button" id="addCategoryBtn" class="btn btn-secondary btn-sm mt-2">Ajouter Catégorie</button>
+        <% } %>
       </div>
       <div class="mb-3">
         <label for="chantierId" class="form-label">Chantier</label>
@@ -142,6 +145,30 @@
             fournisseurSelect.value = val;
           });
         }
+      }
+      const addBtn = document.getElementById('addCategoryBtn');
+      if (addBtn) {
+        addBtn.addEventListener('click', async () => {
+          const nom = prompt('Nouvelle catégorie :');
+          if (!nom) return;
+          const body = new URLSearchParams();
+          body.append('nom', nom);
+          const resp = await fetch('/chantier/ajouter-categorie', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: body.toString()
+          });
+          if (resp.ok) {
+            const select = document.getElementById('categorieSelect');
+            const option = document.createElement('option');
+            option.value = nom;
+            option.textContent = nom;
+            select.appendChild(option);
+            select.value = nom;
+          } else {
+            alert("Erreur lors de l'ajout de la catégorie");
+          }
+        });
       }
     });
   </script>

--- a/views/chantier/modifierMaterielChantier.ejs
+++ b/views/chantier/modifierMaterielChantier.ejs
@@ -13,30 +13,19 @@
 
       <div class="mb-3">
   <label for="categorieSelect" class="form-label">Catégorie</label>
+  <% const cats = categories || []; %>
   <select class="form-select" name="categorie" id="categorieSelect" required>
     <option value="">-- Choisir une catégorie --</option>
-    <%
-      const currentCat = (mc.materiel.categorie || '').toLowerCase();
-    %>
-    <option value="agencement" <%= currentCat === 'agencement' ? 'selected' : '' %>>AGENCEMENT</option>
-    <option value="cvc" <%= currentCat === 'cvc' ? 'selected' : '' %>>CVC</option>
-    <option value="conso" <%= currentCat === 'conso' ? 'selected' : '' %>>Conso</option>
-    <option value="menuiserie" <%= currentCat === 'menuiserie' ? 'selected' : '' %>>MENUISERIE</option>
-    <option value="menuiserie ext" <%= currentCat === 'menuiserie ext' ? 'selected' : '' %>>MENUISERIE EXT</option>
-    <option value="mobilier" <%= currentCat === 'mobilier' ? 'selected' : '' %>>MOBILIER</option>
-    <option value="peinture" <%= currentCat === 'peinture' ? 'selected' : '' %>>PEINTURE</option>
-    <option value="revetement mural / revetement sol" <%= currentCat === 'revetement mural / revetement sol' ? 'selected' : '' %>>REVÊTEMENT MURAL / REVÊTEMENT SOL</option>
-    <option value="platrerie" <%= currentCat === 'platrerie' ? 'selected' : '' %>>PLÂTRERIE</option>
-    <option value="sol" <%= currentCat === 'sol' ? 'selected' : '' %>>SOL</option>
-    <option value="st" <%= currentCat === 'st' ? 'selected' : '' %>>ST</option>
-    <option value="stockage dechets" <%= currentCat === 'stockage dechets' ? 'selected' : '' %>>Stockage Déchets</option>
-    <option value="plomberie" <%= currentCat === 'plomberie' ? 'selected' : '' %>>plomberie</option>
-    <option value="Electricité"
-      <%= ['electricite', 'électricité', 'electricité'].includes(currentCat) ? 'selected' : '' %>>
-        ÉLECTRICITÉ
-    </option>
-    <option value="climatisation" <%= currentCat === 'climatisation' ? 'selected' : '' %>>CLIMATISATION</option>
+    <% cats.forEach(function(cat){ %>
+      <option value="<%= cat %>" <%= mc.materiel.categorie === cat ? 'selected' : '' %>><%= cat %></option>
+    <% }) %>
+    <% if (mc.materiel.categorie && !cats.includes(mc.materiel.categorie)) { %>
+      <option value="<%= mc.materiel.categorie %>" selected><%= mc.materiel.categorie %></option>
+    <% } %>
   </select>
+  <% if (user && user.role === 'admin') { %>
+    <button type="button" id="addCategoryBtn" class="btn btn-secondary btn-sm mt-2">Ajouter Catégorie</button>
+  <% } %>
 </div>
 
       <div class="mb-3">
@@ -211,6 +200,30 @@
         }
       }
 
+      const addBtn = document.getElementById('addCategoryBtn');
+      if (addBtn) {
+        addBtn.addEventListener('click', async () => {
+          const nom = prompt('Nouvelle catégorie :');
+          if (!nom) return;
+          const body = new URLSearchParams();
+          body.append('nom', nom);
+          const resp = await fetch('/chantier/ajouter-categorie', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: body.toString()
+          });
+          if (resp.ok) {
+            const select = document.getElementById('categorieSelect');
+            const option = document.createElement('option');
+            option.value = nom;
+            option.textContent = nom;
+            select.appendChild(option);
+            select.value = nom;
+          } else {
+            alert("Erreur lors de l'ajout de la catégorie");
+          }
+        });
+      }
       initDesignationDropdown("categorieSelect", "designationSelect", "nomMateriel");
     });
   </script>


### PR DESCRIPTION
## Summary
- allow admins to create new categories for chantier materials
- persist categories in config file and load them dynamically
- add "Ajouter Catégorie" button and helper scripts to manage list

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c7ce312d3c8328b742a98471ca0530