### PR TITLE
Rendre la liste des catégories dynamique

### DIFF
--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -105,10 +105,12 @@ router.get('/', ensureAuthenticated, async (req, res) => {
 
     const chantiers = await Chantier.findAll(); // Pour la liste déroulante
     const emplacements = await Emplacement.findAll(); // AJOUTÉ
+    const categories = loadCategories();
     res.render('chantier/index', {
   materielChantiers,
   chantiers,
   emplacements,
+  categories,
   chantierId,
   nomMateriel,
   categorie,

--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -131,20 +131,9 @@
   <label for="categorieSelect" class="form-label">Catégorie</label>
   <select class="form-select" name="categorie" id="categorieSelect">
     <option value="">-- Toutes les catégories --</option>
-    <option value="Plomberie" <%= categorie === 'Plomberie' ? 'selected' : '' %>>Plomberie</option>
-    <option value="Electricité" <%= categorie === 'Electricité' ? 'selected' : '' %>>Electricité</option>
-    <option value="Climatisation" <%= categorie === 'Climatisation' ? 'selected' : '' %>>Climatisation</option>
-    <option value="Chauffage" <%= categorie === 'Chauffage' ? 'selected' : '' %>>Chauffage</option>
-    <option value="Revêtement mural" <%= categorie === 'Revêtement mural' ? 'selected' : '' %>>Revêtement mural</option>
-    <option value="Revêtement mural / Revêtement Sol" <%= categorie === 'Revêtement mural / Revêtement Sol' ? 'selected' : '' %>>Revêtement mural / Revêtement Sol</option>
-    <option value="Maçonnerie" <%= categorie === 'Maçonnerie' ? 'selected' : '' %>>Maçonnerie</option>
-    <option value="Menuiserie" <%= categorie === 'Menuiserie' ? 'selected' : '' %>>Menuiserie</option>
-      <option value="Mobilier" <%= categorie === 'Mobilier' ? 'selected' : '' %>>Mobilier</option>
-    <option value="Peinture" <%= categorie === 'Peinture' ? 'selected' : '' %>>Peinture</option>
-    <option value="Agencement" <%= categorie === 'Agencement' ? 'selected' : '' %>>Agencement</option>
-    <option value="Fixation/Visserie" <%= categorie === 'Fixation/Visserie' ? 'selected' : '' %>>Fixation/Visserie</option>
- 
-    <option value="Autre" <%= categorie === 'Autre' ? 'selected' : '' %>>Autre</option>
+    <% (categories || []).forEach(function(cat){ %>
+      <option value="<%= cat %>" <%= categorie === cat ? 'selected' : '' %>><%= cat %></option>
+    <% }); %>
   </select>
 </div>
 


### PR DESCRIPTION
## Summary
- load categories from configuration when displaying chantier inventory
- render category filter dynamically from stored categories

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c7d179f0c48328b8ca093a20b0299c