### PR TITLE
feat: add planned delivery tracking for chantier materials

### DIFF
--- a/models/MaterielChantier.js
+++ b/models/MaterielChantier.js
@@ -24,6 +24,19 @@ const MaterielChantier = sequelize.define(
       },
     },
 
+    quantitePrevue: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      validate: {
+        min: 0,
+      },
+    },
+
+    dateLivraisonPrevue: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+
     remarque: {
       type: DataTypes.TEXT,
       allowNull: true,

--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -160,8 +160,10 @@ router.post('/ajouter-categorie', ensureAuthenticated, checkAdmin, async (req, r
 
 router.post('/ajouterMateriel', ensureAuthenticated, checkAdmin, upload.array('photos', 5), async (req, res) => {
   try {
-    const { nom, reference, quantite, description, prix, categorie, fournisseur, chantierId, emplacementId, rack, compartiment, niveau, remarque } = req.body;
+    const { nom, reference, quantite, quantitePrevue, dateLivraisonPrevue, description, prix, categorie, fournisseur, chantierId, emplacementId, rack, compartiment, niveau, remarque } = req.body;
     const prixNumber = prix ? parseFloat(prix) : null;
+    const qtePrevue = quantitePrevue ? parseInt(quantitePrevue, 10) : null;
+    const datePrevue = dateLivraisonPrevue ? new Date(dateLivraisonPrevue) : null;
 
     await Categorie.findOrCreate({ where: { nom: categorie } });
 
@@ -199,6 +201,8 @@ router.post('/ajouterMateriel', ensureAuthenticated, checkAdmin, upload.array('p
       chantierId: parseInt(chantierId, 10),
       materielId: nouveauMateriel.id,
       quantite: qte,
+      quantitePrevue: qtePrevue,
+      dateLivraisonPrevue: datePrevue,
       remarque: remarque || null
     });
 
@@ -413,7 +417,7 @@ router.get('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, as
 router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, upload.single('photo'), async (req, res) => {
   try {
       const {
-        quantite, nomMateriel, categorie, fournisseur, emplacementId,
+        quantite, quantitePrevue, dateLivraisonPrevue, nomMateriel, categorie, fournisseur, emplacementId,
         rack, compartiment, niveau, reference, description, prix, remarque
       } = req.body;
 
@@ -428,6 +432,12 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
     const newQte = (quantite === undefined || quantite === '')
       ? mc.quantite
       : parseInt(quantite, 10);
+    const newQtePrevue = (quantitePrevue === undefined || quantitePrevue === '')
+      ? mc.quantitePrevue
+      : parseInt(quantitePrevue, 10);
+    const newDatePrevue = (dateLivraisonPrevue === undefined || dateLivraisonPrevue === '')
+      ? mc.dateLivraisonPrevue
+      : new Date(dateLivraisonPrevue);
 
     if (
       isNaN(newQte) || newQte < 0 ||
@@ -450,6 +460,8 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
     const oldDescription = mc.materiel.description;
       const oldPrix = mc.materiel.prix;
       const oldRemarque = mc.remarque;
+    const oldQtePrevue = mc.quantitePrevue;
+    const oldDatePrevue = mc.dateLivraisonPrevue;
 
     const newNom = nomMateriel.trim();
     const newCategorie = categorie;
@@ -476,9 +488,14 @@ router.post('/materielChantier/modifier/:id', ensureAuthenticated, checkAdmin, u
     if (oldDescription !== newDescription) changementsDetail.push(`Description: ${oldDescription || '-'} ➔ ${newDescription || '-'}`);
       if (oldPrix !== newPrix) changementsDetail.push(`Prix: ${oldPrix || '-'} ➔ ${newPrix || '-'}`);
       if (oldRemarque !== newRemarque) changementsDetail.push(`Remarque: ${oldRemarque || '-'} ➔ ${newRemarque || '-'}`);
+    if (oldQtePrevue !== newQtePrevue) changementsDetail.push(`Quantité prévue: ${oldQtePrevue || '-'} ➔ ${newQtePrevue || '-'}`);
+    if ( (oldDatePrevue ? oldDatePrevue.toISOString().split('T')[0] : '') !== (newDatePrevue ? newDatePrevue.toISOString().split('T')[0] : '') )
+      changementsDetail.push(`Date prévue: ${oldDatePrevue ? oldDatePrevue.toISOString().split('T')[0] : '-'} ➔ ${newDatePrevue ? newDatePrevue.toISOString().split('T')[0] : '-'}`);
 
     // Mise à jour
     mc.quantite = newQte;
+    mc.quantitePrevue = newQtePrevue;
+    mc.dateLivraisonPrevue = newDatePrevue;
     mc.materiel.nom = newNom;
     mc.materiel.categorie = newCategorie;
     mc.materiel.emplacementId = newEmplacement;
@@ -574,8 +591,10 @@ router.get('/materielChantier/dupliquer/:id', ensureAuthenticated, checkAdmin, a
 
 router.post('/materielChantier/dupliquer/:id', ensureAuthenticated, checkAdmin, upload.single('photo'), async (req, res) => {
   try {
-      const { nom, reference, quantite, description, prix, categorie, fournisseur, chantierId, emplacementId, remarque } = req.body;
+      const { nom, reference, quantite, quantitePrevue, dateLivraisonPrevue, description, prix, categorie, fournisseur, chantierId, emplacementId, remarque } = req.body;
     const prixNumber = prix ? parseFloat(prix) : null;
+    const qtePrevue = quantitePrevue ? parseInt(quantitePrevue, 10) : null;
+    const datePrevue = dateLivraisonPrevue ? new Date(dateLivraisonPrevue) : null;
 
     await Categorie.findOrCreate({ where: { nom: categorie } });
 
@@ -605,6 +624,8 @@ router.post('/materielChantier/dupliquer/:id', ensureAuthenticated, checkAdmin, 
         chantierId: parseInt(chantierId),
         materielId: nouveauMateriel.id,
         quantite: parseInt(quantite),
+        quantitePrevue: qtePrevue,
+        dateLivraisonPrevue: datePrevue,
         remarque: remarque || null
       });
 

--- a/views/chantier/ajouterMateriel.ejs
+++ b/views/chantier/ajouterMateriel.ejs
@@ -193,6 +193,17 @@ select#emplacementId.form-control {
         <input type="number" name="quantite" id="quantite" class="form-control" required>
       </div>
       <div class="mb-3">
+        <label for="quantitePrevue" class="form-label">Quantité prévue</label>
+        <input type="number" name="quantitePrevue" id="quantitePrevue" class="form-control">
+      </div>
+      <div class="mb-3">
+        <label for="dateLivraisonPrevue" class="form-label">Date de livraison prévue</label>
+        <div class="input-group">
+          <span class="input-group-text">📅</span>
+          <input type="date" name="dateLivraisonPrevue" id="dateLivraisonPrevue" class="form-control">
+        </div>
+      </div>
+      <div class="mb-3">
         <label for="description" class="form-label">Description</label>
         <textarea name="description" id="description" class="form-control"></textarea>
       </div>

--- a/views/chantier/dupliquerMaterielChantier.ejs
+++ b/views/chantier/dupliquerMaterielChantier.ejs
@@ -21,10 +21,21 @@
         <label for="quantite" class="form-label">Quantité</label>
         <input type="number" name="quantite" id="quantite" class="form-control" value="<%= mc.quantite %>" required>
       </div>
-    <div class="mb-3">
-      <label for="description" class="form-label">Description</label>
-      <textarea name="description" id="description" class="form-control"><%= mc.materiel.description || '' %></textarea>
-    </div>
+      <div class="mb-3">
+        <label for="quantitePrevue" class="form-label">Quantité prévue</label>
+        <input type="number" name="quantitePrevue" id="quantitePrevue" class="form-control" value="<%= mc.quantitePrevue || '' %>">
+      </div>
+      <div class="mb-3">
+        <label for="dateLivraisonPrevue" class="form-label">Date de livraison prévue</label>
+        <div class="input-group">
+          <span class="input-group-text">📅</span>
+          <input type="date" name="dateLivraisonPrevue" id="dateLivraisonPrevue" class="form-control" value="<%= mc.dateLivraisonPrevue ? mc.dateLivraisonPrevue.toISOString().split('T')[0] : '' %>">
+        </div>
+      </div>
+      <div class="mb-3">
+        <label for="description" class="form-label">Description</label>
+        <textarea name="description" id="description" class="form-control"><%= mc.materiel.description || '' %></textarea>
+      </div>
     <div class="mb-3">
       <label for="remarque" class="form-label">Remarque</label>
       <textarea name="remarque" id="remarque" class="form-control"></textarea>

--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -182,6 +182,8 @@
           <th>Compartiment</th>
           <th>Niveau</th>
           <th>Qte</th>
+          <th>Qte prévue</th>
+          <th>Date prévue</th>
 
         </tr>
       </thead>
@@ -292,6 +294,8 @@
 
 
               <td><%= mc.quantite %></td>
+              <td><%= mc.quantitePrevue != null ? mc.quantitePrevue : '-' %></td>
+              <td><%= mc.dateLivraisonPrevue ? mc.dateLivraisonPrevue.toISOString().split('T')[0] : '-' %></td>
               <td>
 
                 <% if (user && user.role === 'admin') { %>

--- a/views/chantier/infoMaterielChantier.ejs
+++ b/views/chantier/infoMaterielChantier.ejs
@@ -37,6 +37,8 @@
         <p><strong>🗒️ Remarque :</strong> <%= mc.remarque || '-' %></p>
         <p><strong>🏷️ Catégorie :</strong> <%= mc.materiel.categorie || '-' %></p>
         <p><strong>🔢 Quantité sur le chantier :</strong> <%= mc.quantite %></p>
+        <p><strong>🔮 Quantité prévue :</strong> <%= mc.quantitePrevue != null ? mc.quantitePrevue : '-' %></p>
+        <p><strong>📅 Date de livraison prévue :</strong> <%= mc.dateLivraisonPrevue ? mc.dateLivraisonPrevue.toISOString().split('T')[0] : '-' %></p>
         <p><strong>🏗️ Chantier :</strong> <%= mc.chantier.nom %></p>
         <p><strong>📍 Emplacement :</strong> <%= mc.materiel.emplacement ? mc.materiel.emplacement.nom : '-' %></p>
         <p><strong>📦 Rack :</strong> <%= mc.materiel.rack || '-' %></p>

--- a/views/chantier/modifierMaterielChantier.ejs
+++ b/views/chantier/modifierMaterielChantier.ejs
@@ -40,6 +40,17 @@
           <button type="button" class="btn btn-outline-secondary" onclick="changerQuantite(1)">+</button>
         </div>
       </div>
+      <div class="mb-3">
+        <label for="quantitePrevue" class="form-label">Quantité prévue</label>
+        <input type="number" name="quantitePrevue" id="quantitePrevue" class="form-control" value="<%= mc.quantitePrevue || '' %>" min="0">
+      </div>
+      <div class="mb-3">
+        <label for="dateLivraisonPrevue" class="form-label">Date de livraison prévue</label>
+        <div class="input-group">
+          <span class="input-group-text">📅</span>
+          <input type="date" name="dateLivraisonPrevue" id="dateLivraisonPrevue" class="form-control" value="<%= mc.dateLivraisonPrevue ? mc.dateLivraisonPrevue.toISOString().split('T')[0] : '' %>">
+        </div>
+      </div>
 
       <div class="mb-3">
   <label for="designationSelect" class="form-label">Désignation</label>


### PR DESCRIPTION
## Summary
- support `quantitePrevue` and `dateLivraisonPrevue` on chantier materials
- show and edit planned quantity and delivery date across chantier forms

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68c7dd2372f08328b2d5442934950be1