### PR TITLE
feat: ajout recherche globale materiel chantier

### DIFF
--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -26,7 +26,7 @@ const upload = multer({ storage });
 /* ===== INVENTAIRE CUMULÉ CHANTIER ===== */
 router.get('/', ensureAuthenticated, async (req, res) => {
   try {
-    const { chantierId, nomMateriel, categorie, emplacement, description, triNom, triAjout, triModification } = req.query;
+    const { chantierId, nomMateriel, categorie, emplacement, description, triNom, triAjout, triModification, recherche } = req.query;
 
     const whereChantier = chantierId ? { chantierId: chantierId } : {};
     const whereMateriel = {};
@@ -55,7 +55,7 @@ router.get('/', ensureAuthenticated, async (req, res) => {
       order.push([{ model: Materiel, as: 'materiel' }, 'updatedAt', triModification.toUpperCase()]);
     }
 
-    const materielChantiers = await MaterielChantier.findAll({
+    let materielChantiers = await MaterielChantier.findAll({
   where: whereChantier,
   include: [
     { model: Chantier, as: 'chantier' },
@@ -92,6 +92,14 @@ router.get('/', ensureAuthenticated, async (req, res) => {
 
 });
 
+    if (recherche) {
+      const terme = recherche.toLowerCase();
+      materielChantiers = materielChantiers.filter(mc => {
+        const contenu = JSON.stringify(mc.get({ plain: true })).toLowerCase();
+        return contenu.includes(terme);
+      });
+    }
+
 
     const chantiers = await Chantier.findAll(); // Pour la liste déroulante
     const emplacements = await Emplacement.findAll(); // AJOUTÉ
@@ -108,7 +116,8 @@ router.get('/', ensureAuthenticated, async (req, res) => {
   description,
   triNom,
   triAjout,
-  triModification
+  triModification,
+  recherche
 });
 
   } catch (err) {

--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -158,6 +158,12 @@
 </div>
 
 
+ <div class="col-md-3">
+   <label for="recherche" class="form-label">Recherche générale</label>
+   <input type="text" class="form-control" name="recherche" id="recherche" value="<%= recherche || '' %>">
+ </div>
+
+
   <div class="col-12 mt-2">
     <button type="submit" class="btn btn-primary">Appliquer les filtres</button>
     <a href="/chantier" class="btn btn-secondary">Réinitialiser</a>


### PR DESCRIPTION
## Summary
- add global search field on chantier inventory page
- filter chantier materials list with general search parameter

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c7dfa9b2d48328b7b7ddc8becda7a6