### PR TITLE
Rendre l'en-tête du tableau matériel chantier fixe au scroll

### DIFF
--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -25,6 +25,16 @@
     body.mode-sombre .table-striped > tbody > tr:nth-of-type(odd) {
       --bs-table-accent-bg: #2a2a2a;
     }
+    .table-materiel thead th {
+      position: sticky;
+      top: 70px;
+      z-index: 5;
+      background-color: #f8f9fa;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+    }
+    body.mode-sombre .table-materiel thead th {
+      background-color: #2c2c2c;
+    }
     .form-select {
       appearance: none !important;
       -webkit-appearance: none !important;


### PR DESCRIPTION
## Summary
- ajoute un style sticky à l'en-tête du tableau des matériels chantier pour qu'il reste visible lors du défilement
- assure un fond adapté en mode clair et sombre et ajoute une légère ombre pour distinguer le bandeau

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68c91b2b0ac48328b138ad632a95f734