### PR TITLE
Ajoute confirmation modale avant suppression de catégorie

### DIFF
--- a/public/js/categoryDeletionModal.js
+++ b/public/js/categoryDeletionModal.js
@@ -1,0 +1,88 @@
+(() => {
+  function setupCategoryDeletionModal(options = {}) {
+    const {
+      triggerId,
+      selectId,
+      modalId,
+      confirmBtnId,
+      nameSelector = '[data-category-name]',
+      onSuccess,
+    } = options;
+
+    const triggerBtn = triggerId ? document.getElementById(triggerId) : null;
+    const select = selectId ? document.getElementById(selectId) : null;
+    const modalEl = modalId ? document.getElementById(modalId) : null;
+    const confirmBtn = confirmBtnId ? document.getElementById(confirmBtnId) : null;
+    const nameEl = modalEl ? modalEl.querySelector(nameSelector) : null;
+
+    if (!triggerBtn || !select || !modalEl || !confirmBtn || !nameEl) {
+      return;
+    }
+
+    if (typeof bootstrap === 'undefined' || !bootstrap.Modal) {
+      console.warn('Bootstrap Modal est requis pour la confirmation de suppression de catégorie.');
+      return;
+    }
+
+    const modalInstance = new bootstrap.Modal(modalEl);
+    let pendingValue = null;
+    const originalConfirmText = confirmBtn.textContent;
+
+    const resetConfirmButton = () => {
+      confirmBtn.disabled = false;
+      confirmBtn.textContent = originalConfirmText;
+    };
+
+    triggerBtn.addEventListener('click', () => {
+      const value = select.value;
+      if (!value) {
+        alert('Veuillez sélectionner une catégorie à supprimer.');
+        return;
+      }
+      pendingValue = value;
+      nameEl.textContent = value;
+      modalInstance.show();
+    });
+
+    modalEl.addEventListener('hidden.bs.modal', () => {
+      pendingValue = null;
+      resetConfirmButton();
+    });
+
+    confirmBtn.addEventListener('click', async () => {
+      if (!pendingValue) {
+        return;
+      }
+
+      confirmBtn.disabled = true;
+      confirmBtn.textContent = 'Suppression...';
+
+      const body = new URLSearchParams();
+      body.append('nom', pendingValue);
+
+      try {
+        const response = await fetch('/chantier/supprimer-categorie', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: body.toString(),
+        });
+
+        if (!response.ok) {
+          const data = await response.json().catch(() => null);
+          throw new Error(data?.message || "Erreur lors de la suppression de la catégorie");
+        }
+
+        if (typeof onSuccess === 'function') {
+          onSuccess({ value: pendingValue, select });
+        }
+
+        modalInstance.hide();
+      } catch (error) {
+        alert(error.message || "Erreur lors de la suppression de la catégorie");
+        resetConfirmButton();
+      }
+    });
+  }
+
+  window.setupCategoryDeletionModal = setupCategoryDeletionModal;
+})();

--- a/views/chantier/ajouterMateriel.ejs
+++ b/views/chantier/ajouterMateriel.ejs
@@ -178,6 +178,7 @@ select#emplacementId.form-control {
             <button type="button" id="addCategoryBtn" class="btn btn-secondary btn-sm">Ajouter Catégorie</button>
             <button type="button" id="deleteCategoryBtn" class="btn btn-danger btn-sm">Supprimer Catégorie</button>
           </div>
+          <%- include('chantier/partials/deleteCategoryModal') %>
         <% } %>
       </div>
       <div class="mb-3">
@@ -301,6 +302,7 @@ select#emplacementId.form-control {
     <p><a href="/chantier" class="btn btn-secondary mt-3">Retour au Dashboard Chantier</a></p>
   </div>
   <script src="/js/bootstrap.bundle.min.js"></script>
+  <script src="/js/categoryDeletionModal.js"></script>
   <script nonce="<%= nonce %>">
     document.addEventListener('DOMContentLoaded', function () {
       const fournisseurSelect = document.getElementById('fournisseurSelect');
@@ -348,38 +350,22 @@ select#emplacementId.form-control {
           }
         });
       }
-      const deleteBtn = document.getElementById('deleteCategoryBtn');
-      if (deleteBtn) {
-        deleteBtn.addEventListener('click', async () => {
-          const select = document.getElementById('categorieSelect');
-          if (!select) return;
-          const valeur = select.value;
-          if (!valeur) {
-            alert('Veuillez sélectionner une catégorie à supprimer.');
-            return;
-          }
-          if (!confirm(`Supprimer la catégorie "${valeur}" ? Elle sera retirée de tous les matériels.`)) {
-            return;
-          }
-          const body = new URLSearchParams();
-          body.append('nom', valeur);
-          const resp = await fetch('/chantier/supprimer-categorie', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: body.toString()
-          });
-          if (resp.ok) {
+      if (typeof setupCategoryDeletionModal === 'function') {
+        setupCategoryDeletionModal({
+          triggerId: 'deleteCategoryBtn',
+          selectId: 'categorieSelect',
+          modalId: 'deleteCategoryModal',
+          confirmBtnId: 'confirmDeleteCategoryBtn',
+          nameSelector: '[data-category-name]',
+          onSuccess: ({ value, select }) => {
             Array.from(select.options).forEach(opt => {
-              if (opt.value === valeur) opt.remove();
+              if (opt.value === value) opt.remove();
             });
             select.value = '';
             if (select.value) {
               select.selectedIndex = -1;
             }
             select.dispatchEvent(new Event('change'));
-          } else {
-            const data = await resp.json().catch(() => null);
-            alert(data?.message || "Erreur lors de la suppression de la catégorie");
           }
         });
       }

--- a/views/chantier/dupliquerMaterielChantier.ejs
+++ b/views/chantier/dupliquerMaterielChantier.ejs
@@ -92,6 +92,7 @@
             <button type="button" id="addCategoryBtn" class="btn btn-secondary btn-sm">Ajouter Catégorie</button>
             <button type="button" id="deleteCategoryBtn" class="btn btn-danger btn-sm">Supprimer Catégorie</button>
           </div>
+          <%- include('chantier/partials/deleteCategoryModal') %>
         <% } %>
       </div>
       <div class="mb-3">
@@ -123,6 +124,7 @@
     </form>
   </div>
   <script src="/js/bootstrap.bundle.min.js"></script>
+  <script src="/js/categoryDeletionModal.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function () {
       const select = document.getElementById('categorieSelect');
@@ -188,38 +190,22 @@
           }
         });
       }
-      const deleteBtn = document.getElementById('deleteCategoryBtn');
-      if (deleteBtn) {
-        deleteBtn.addEventListener('click', async () => {
-          const selectCat = document.getElementById('categorieSelect');
-          if (!selectCat) return;
-          const valeur = selectCat.value;
-          if (!valeur) {
-            alert('Veuillez sélectionner une catégorie à supprimer.');
-            return;
-          }
-          if (!confirm(`Supprimer la catégorie "${valeur}" ? Elle sera retirée de tous les matériels.`)) {
-            return;
-          }
-          const body = new URLSearchParams();
-          body.append('nom', valeur);
-          const resp = await fetch('/chantier/supprimer-categorie', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: body.toString()
-          });
-          if (resp.ok) {
-            Array.from(selectCat.options).forEach(opt => {
-              if (opt.value === valeur) opt.remove();
+      if (typeof setupCategoryDeletionModal === 'function') {
+        setupCategoryDeletionModal({
+          triggerId: 'deleteCategoryBtn',
+          selectId: 'categorieSelect',
+          modalId: 'deleteCategoryModal',
+          confirmBtnId: 'confirmDeleteCategoryBtn',
+          nameSelector: '[data-category-name]',
+          onSuccess: ({ value, select }) => {
+            Array.from(select.options).forEach(opt => {
+              if (opt.value === value) opt.remove();
             });
-            selectCat.value = '';
-            if (selectCat.value) {
-              selectCat.selectedIndex = -1;
+            select.value = '';
+            if (select.value) {
+              select.selectedIndex = -1;
             }
-            selectCat.dispatchEvent(new Event('change'));
-          } else {
-            const data = await resp.json().catch(() => null);
-            alert(data?.message || "Erreur lors de la suppression de la catégorie");
+            select.dispatchEvent(new Event('change'));
           }
         });
       }

--- a/views/chantier/modifierMaterielChantier.ejs
+++ b/views/chantier/modifierMaterielChantier.ejs
@@ -28,6 +28,7 @@
       <button type="button" id="addCategoryBtn" class="btn btn-secondary btn-sm">Ajouter Catégorie</button>
       <button type="button" id="deleteCategoryBtn" class="btn btn-danger btn-sm">Supprimer Catégorie</button>
     </div>
+    <%- include('chantier/partials/deleteCategoryModal') %>
   <% } %>
 </div>
 
@@ -188,6 +189,7 @@
   }
 </script>
   <script src="/js/bootstrap.bundle.min.js"></script>
+  <script src="/js/categoryDeletionModal.js"></script>
   <script nonce="<%= nonce %>">
     document.addEventListener("DOMContentLoaded", function () {
       const fSelect = document.getElementById("fournisseurSelect");
@@ -243,38 +245,22 @@
           }
         });
       }
-      const deleteBtn = document.getElementById('deleteCategoryBtn');
-      if (deleteBtn) {
-        deleteBtn.addEventListener('click', async () => {
-          const selectCat = document.getElementById('categorieSelect');
-          if (!selectCat) return;
-          const valeur = selectCat.value;
-          if (!valeur) {
-            alert('Veuillez sélectionner une catégorie à supprimer.');
-            return;
-          }
-          if (!confirm(`Supprimer la catégorie "${valeur}" ? Elle sera retirée de tous les matériels.`)) {
-            return;
-          }
-          const body = new URLSearchParams();
-          body.append('nom', valeur);
-          const resp = await fetch('/chantier/supprimer-categorie', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: body.toString()
-          });
-          if (resp.ok) {
-            Array.from(selectCat.options).forEach(opt => {
-              if (opt.value === valeur) opt.remove();
+      if (typeof setupCategoryDeletionModal === 'function') {
+        setupCategoryDeletionModal({
+          triggerId: 'deleteCategoryBtn',
+          selectId: 'categorieSelect',
+          modalId: 'deleteCategoryModal',
+          confirmBtnId: 'confirmDeleteCategoryBtn',
+          nameSelector: '[data-category-name]',
+          onSuccess: ({ value, select }) => {
+            Array.from(select.options).forEach(opt => {
+              if (opt.value === value) opt.remove();
             });
-            selectCat.value = '';
-            if (selectCat.value) {
-              selectCat.selectedIndex = -1;
+            select.value = '';
+            if (select.value) {
+              select.selectedIndex = -1;
             }
-            selectCat.dispatchEvent(new Event('change'));
-          } else {
-            const data = await resp.json().catch(() => null);
-            alert(data?.message || "Erreur lors de la suppression de la catégorie");
+            select.dispatchEvent(new Event('change'));
           }
         });
       }

--- a/views/chantier/partials/deleteCategoryModal.ejs
+++ b/views/chantier/partials/deleteCategoryModal.ejs
@@ -1,0 +1,21 @@
+<div class="modal fade" id="deleteCategoryModal" tabindex="-1" aria-labelledby="deleteCategoryModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header bg-danger text-white">
+        <h5 class="modal-title" id="deleteCategoryModalLabel">Confirmer la suppression</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+      </div>
+      <div class="modal-body">
+        Êtes-vous sûr de vouloir supprimer la catégorie
+        <strong data-category-name></strong> ?
+        <div class="mt-2 text-danger">
+          Cette action est irréversible et retirera la catégorie de tous les matériels.
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+        <button type="button" class="btn btn-danger" id="confirmDeleteCategoryBtn">Supprimer</button>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- ajoute un composant de confirmation modale réutilisable pour la suppression de catégorie
- introduit un script côté client partagé pour gérer la confirmation et l’appel API
- branche les formulaires d’ajout, de modification et de duplication du matériel chantier sur cette confirmation

## Testing
- not run (non disponible)


------
https://chatgpt.com/codex/tasks/task_b_68c9272b256083288ea4445ce2ce8f19