### PR TITLE
Ajout de la gestion persistante des désignations par catégorie

### DIFF
--- a/models/Designation.js
+++ b/models/Designation.js
@@ -1,0 +1,45 @@
+const { DataTypes } = require('sequelize');
+const { sequelize } = require('../config/database');
+
+const Designation = sequelize.define(
+  'Designation',
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    nom: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    categorieId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'categories',
+        key: 'id',
+      },
+    },
+  },
+  {
+    tableName: 'designations',
+    timestamps: false,
+    indexes: [
+      {
+        unique: true,
+        fields: ['nom', 'categorieId'],
+      },
+    ],
+  }
+);
+
+Designation.associate = function (models) {
+  Designation.belongsTo(models.Categorie, {
+    foreignKey: 'categorieId',
+    as: 'categorie',
+    onDelete: 'CASCADE',
+  });
+};
+
+module.exports = Designation;

--- a/models/index.js
+++ b/models/index.js
@@ -13,6 +13,7 @@ const MaterielDelivery = require('./MaterielDelivery');
 const Historique       = require('./Historique');
 const Emplacement      = require('./Emplacement');
 const Categorie        = require('./Categorie');
+const Designation      = require('./Designation');
 
 // 📦 Regroupement de tous les modèles
 const models = {
@@ -27,6 +28,7 @@ const models = {
   Historique,
   Emplacement,
   Categorie,
+  Designation,
 };
 
 // Associations manuelles
@@ -56,9 +58,16 @@ User.hasMany(Historique,       { foreignKey: 'userId', as: 'historiques' });
 
 Chantier.hasMany(Emplacement,  { foreignKey: 'chantierId', as: 'emplacements' });
 
+Categorie.hasMany(Designation, {
+  foreignKey: 'categorieId',
+  as: 'designations',
+  onDelete: 'CASCADE',
+});
+
 // 🔁 Appel des .associate() avec tous les modèles déjà définis
 if (typeof Materiel.associate === 'function') Materiel.associate(models);
 if (typeof Emplacement.associate === 'function') Emplacement.associate(models);
+if (typeof Designation.associate === 'function') Designation.associate(models);
 
 /* Export global */
 module.exports = {
@@ -75,4 +84,5 @@ module.exports = {
   Historique,
   Emplacement,
   Categorie,
+  Designation,
 };

--- a/views/chantier/ajouterMateriel.ejs
+++ b/views/chantier/ajouterMateriel.ejs
@@ -186,6 +186,13 @@ select#emplacementId.form-control {
           <option value="">-- Sélectionner une désignation --</option>
         </select>
         <input type="text" name="nom" id="designationInput" class="form-control mt-2" placeholder="Autre désignation">
+        <% if (user && user.role === 'admin') { %>
+          <div class="d-flex flex-wrap gap-2 mt-2">
+            <button type="button" id="addDesignationBtn" class="btn btn-secondary btn-sm">Ajouter une désignation à la catégorie</button>
+            <button type="button" id="deleteDesignationBtn" class="btn btn-danger btn-sm">Supprimer une désignation de la catégorie</button>
+          </div>
+          <div class="form-text d-none" id="designationFeedback"></div>
+        <% } %>
       </div>
       <div class="mb-3">
         <label for="reference" class="form-label">Référence</label>
@@ -363,6 +370,7 @@ select#emplacementId.form-control {
             option.textContent = nom;
             categorieSelect.appendChild(option);
             categorieSelect.value = nom;
+            categorieSelect.dispatchEvent(new Event('change'));
           } else {
             alert("Erreur lors de l'ajout de la catégorie");
           }
@@ -449,7 +457,11 @@ select#emplacementId.form-control {
           pendingCategoryValue = null;
         });
       }
-      initDesignationDropdown('categorieSelect', 'designationSelect', 'designationInput');
+      initDesignationDropdown('categorieSelect', 'designationSelect', 'designationInput', {
+        addButtonId: 'addDesignationBtn',
+        deleteButtonId: 'deleteDesignationBtn',
+        feedbackId: 'designationFeedback'
+      });
       });
   </script>
   <script src="/js/designations.js" nonce="<%= nonce %>"></script>

--- a/views/chantier/modifierMaterielChantier.ejs
+++ b/views/chantier/modifierMaterielChantier.ejs
@@ -61,6 +61,13 @@
     <option value="">-- Sélectionner une désignation --</option>
   </select>
   <input type="text" class="form-control mt-2" id="nomMateriel" name="nomMateriel" value="<%= mc.materiel.nom %>" placeholder="Autre désignation">
+  <% if (user && user.role === 'admin') { %>
+    <div class="d-flex flex-wrap gap-2 mt-2">
+      <button type="button" id="addDesignationBtn" class="btn btn-secondary btn-sm">Ajouter une désignation à la catégorie</button>
+      <button type="button" id="deleteDesignationBtn" class="btn btn-danger btn-sm">Supprimer une désignation de la catégorie</button>
+    </div>
+    <div class="form-text d-none" id="designationFeedback"></div>
+  <% } %>
 </div>
       <div class="mb-3">
         <label for="reference" class="form-label">Référence</label>
@@ -259,6 +266,7 @@
             option.textContent = nom;
             categorieSelect.appendChild(option);
             categorieSelect.value = nom;
+            categorieSelect.dispatchEvent(new Event('change'));
           } else {
             alert("Erreur lors de l'ajout de la catégorie");
           }
@@ -345,7 +353,11 @@
           pendingCategoryValue = null;
         });
       }
-      initDesignationDropdown("categorieSelect", "designationSelect", "nomMateriel");
+      initDesignationDropdown("categorieSelect", "designationSelect", "nomMateriel", {
+        addButtonId: "addDesignationBtn",
+        deleteButtonId: "deleteDesignationBtn",
+        feedbackId: "designationFeedback"
+      });
     });
   </script>
   <script src="/js/designations.js" nonce="<%= nonce %>"></script>


### PR DESCRIPTION
## Summary
- ajoute un modèle `Designation` et les associations nécessaires pour persister les désignations par catégorie
- expose des routes pour consulter, ajouter et supprimer les désignations liées à une catégorie
- enrichit les formulaires de matériel chantier avec des boutons d’administration et un chargement dynamique des désignations

## Testing
- npm run start *(échec : module cloudinary inaccessible dans l’environnement d’exécution)*

------
https://chatgpt.com/codex/tasks/task_b_68c930c32490832887bc7a783bfab9b1