### PR TITLE
Persist chantier filter selection

### DIFF
--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -196,7 +196,7 @@
 
   <div class="col-12 mt-2">
     <button type="submit" class="btn btn-primary">Appliquer les filtres</button>
-    <a href="/chantier" class="btn btn-secondary">Réinitialiser</a>
+    <a href="/chantier?reset=1" class="btn btn-secondary">Réinitialiser</a>
   </div>
 </form>
 


### PR DESCRIPTION
## Summary
- store the last selected chantier filters in the session and reuse them on subsequent visits
- add reset handling so filters can be cleared explicitly and keep the UI link aligned

## Testing
- npm start *(fails: requires sqlite3 package)*

------
https://chatgpt.com/codex/tasks/task_b_68ca865a95b08328a66aa3112c5b9cc7