### PR TITLE
Ensure chantier inventory watermark overlays zebra rows

### DIFF
--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -35,6 +35,34 @@
     body.mode-sombre .table-materiel thead th {
       background-color: #2c2c2c;
     }
+    .watermark {
+      position: fixed;
+      top: 35%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      opacity: 0.08;
+      z-index: 999;
+      pointer-events: none;
+      width: 70%;
+      max-width: 600px;
+    }
+    .watermark img {
+      width: 100%;
+      height: auto;
+      display: block;
+    }
+    .table-materiel tbody tr:nth-child(even) td,
+    .table-materiel tbody tr:nth-child(even) th {
+      background-color: rgba(0, 0, 0, 0.04) !important;
+    }
+    @media print {
+      .watermark {
+        position: fixed;
+        top: 40%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+      }
+    }
     .form-select {
       appearance: none !important;
       -webkit-appearance: none !important;
@@ -61,6 +89,9 @@
   </style>
 </head>
 <body>
+  <div class="watermark">
+    <img src="/images/logo.png" alt="Logo filigrane">
+  </div>
   <nav class="navbar navbar-light bg-light fixed-top">
     <div class="container-fluid">
       <span class="navbar-brand mb-0 h1">Stock Chantier</span>


### PR DESCRIPTION
## Summary
- add a fixed-position watermark overlay with the chantier logo so it remains visible across the inventory export
- adjust table striping to use semi-transparent rgba hues and keep the watermark fixed when printing

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68cbe9a1ef748328be08d95fafc50cd8