### PR TITLE
Make materiel price optional

### DIFF
--- a/models/Materiel.js
+++ b/models/Materiel.js
@@ -10,7 +10,7 @@ const Materiel = sequelize.define(
     barcode: { type: DataTypes.STRING, unique: true },
     quantite: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
     description: { type: DataTypes.TEXT },
-    prix: { type: DataTypes.DECIMAL(10, 2) },
+    prix: { type: DataTypes.DECIMAL(10, 2), allowNull: true },
     categorie: { type: DataTypes.STRING },
     fournisseur: { type: DataTypes.STRING },
     rack: { type: DataTypes.STRING },

--- a/routes/materiel.js
+++ b/routes/materiel.js
@@ -261,27 +261,21 @@ router.get('/ajouter', ensureAuthenticated, checkAdmin, (req, res) => {
 router.post('/ajouter', ensureAuthenticated, checkAdmin, upload.array('photos', 5), async (req, res) => {
   try {
     const {
-      nom,
-      reference,
-      barcode,   // <-- on récupère le code scanné s'il y en a un
-      quantite,
-      description,
       prix,
-      categorie,
+      quantite,
+      niveau,
       rack,
       compartiment,
-      niveau,
-      position
+      position,
+      ...rest
     } = req.body;
 
+    const prixValue = prix && prix.trim() !== '' ? parseFloat(prix) : null;
+
     const nouveauMateriel = await Materiel.create({
-      nom,
-      reference,
-      barcode,
+      ...rest,
       quantite: parseInt(quantite, 10),
-      description,
-      prix: parseFloat(prix),
-      categorie,
+      prix: prixValue,
       rack: rack || null,
       compartiment: compartiment || null,
       niveau: niveau ? parseInt(niveau, 10) : null,

--- a/views/materiel/ajouter.ejs
+++ b/views/materiel/ajouter.ejs
@@ -98,7 +98,7 @@
 
           <div class="mb-3">
             <label for="prix" class="form-label">Prix</label>
-            <input type="number" step="0.01" name="prix" id="prix" class="form-control" required>
+            <input type="number" step="0.01" name="prix" id="prix" class="form-control" placeholder="Optionnel">
           </div>
 
           <div class="mb-3">

--- a/views/materiel/dashboard.ejs
+++ b/views/materiel/dashboard.ejs
@@ -342,7 +342,6 @@
                 <th>Catégorie</th>
                 <th>Emplacement stock</th>
                 <th>Description</th>
-                <th>Prix</th>
                 <th>Photos</th>
                 <th>Actions</th>
               </tr>
@@ -361,7 +360,6 @@
                   <td><%= m.categorie %></td>
                   <td><%= formatEmplacement(m) %></td>
                   <td><%= m.description %></td>
-                  <td><%= m.prix %> €</td>
                   <td>
                       <% if (m.photos && m.photos.length > 0) { %>
                         <% m.photos.forEach(function(photo) { %>
@@ -406,7 +404,6 @@
           <% const mobileEmplacement = formatEmplacement(m); %>
           <li><strong>Emplacement :</strong> <%= mobileEmplacement %></li>
           <li><strong>Description :</strong> <%= m.description %></li>
-          <li><strong>Prix :</strong> <%= m.prix %> €</li>
           <li>
               <strong>Photos :</strong>
               <% if (m.photos.length) { %>


### PR DESCRIPTION
## Summary
- allow Materiel.prix to be nullable and persist null when no price is provided
- update the add form and dashboard UI so the optional price field is hidden in the stock view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cc0a296eac832892b9b576dd74077d