### PR TITLE
Normalize optional barcode handling

### DIFF
--- a/models/Materiel.js
+++ b/models/Materiel.js
@@ -7,7 +7,7 @@ const Materiel = sequelize.define(
     id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
     nom: { type: DataTypes.STRING, allowNull: false },
     reference: { type: DataTypes.STRING },
-    barcode: { type: DataTypes.STRING, unique: true },
+    barcode: { type: DataTypes.STRING, allowNull: true, unique: true },
     quantite: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
     description: { type: DataTypes.TEXT },
     prix: { type: DataTypes.DECIMAL(10, 2), allowNull: true },


### PR DESCRIPTION
## Summary
- trim barcode values received from forms and scans, store null when the field is left blank
- allow the `Materiel` model to persist null barcodes while keeping the uniqueness constraint
- sanitize other optional string inputs when creating a material

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cc0be5ccb08328938a28135b8ce86b