### PR TITLE
Update matériel category options

### DIFF
--- a/views/materiel/ajouter.ejs
+++ b/views/materiel/ajouter.ejs
@@ -104,17 +104,17 @@
           <div class="mb-3">
             <label for="categorie" class="form-label">Catégorie</label>
             <select name="categorie" id="categorie" class="form-select" required>
+              <option value="">-- Choisir une catégorie --</option>
+              <option value="Électricité">Électricité</option>
               <option value="Plomberie">Plomberie</option>
-              <option value="Electricité">Electricité</option>
-              <option value="Climatisation">Climatisation</option>
-              <option value="Chauffage">Chauffage</option>
-              <option value="Revêtement mural / Revêtement Sol">Revêtement mural / Revêtement Sol</option>
-              <option value="Enduit">Enduit</option>
-              <option value="Maçonnerie">Maçonnerie</option>
-              <option value="Ventilation">Ventilation</option>
-              <option value="Menuiserie">Menuiserie</option>
-              <option value="Electroportatif">Electroportatif</option>
-              <option value="Autre" selected>Autre</option>
+              <option value="CVC">CVC</option>
+              <option value="Plâtrerie">Plâtrerie</option>
+              <option value="Menuiserie INT">Menuiserie INT</option>
+              <option value="Menuiserie EXT">Menuiserie EXT</option>
+              <option value="Revêtement de sol">Revêtement de sol</option>
+              <option value="Revêtement mural">Revêtement mural</option>
+              <option value="Quincaillerie">Quincaillerie</option>
+              <option value="Fixations (visseries, colles…)">Fixations (visseries, colles…)</option>
             </select>
           </div>
 

--- a/views/materiel/dashboard.ejs
+++ b/views/materiel/dashboard.ejs
@@ -144,17 +144,16 @@
             <label for="categorie" class="form-label">Catégorie</label>
             <select name="categorie" id="categorie" class="form-select">
               <option value="">Toutes catégories</option>
-              <option value="Plomberie"        <%= (query.categorie === 'Plomberie')        ? 'selected' : '' %>>Plomberie</option>
-              <option value="Electricité"      <%= (query.categorie === 'Electricité')      ? 'selected' : '' %>>Electricité</option>
-              <option value="Climatisation"    <%= (query.categorie === 'Climatisation')    ? 'selected' : '' %>>Climatisation</option>
-              <option value="Chauffage"        <%= (query.categorie === 'Chauffage')        ? 'selected' : '' %>>Chauffage</option>
-              <option value="Revêtement mural / Revêtement Sol" <%= (query.categorie === 'Revêtement mural / Revêtement Sol') ? 'selected' : '' %>>Revêtement mural / Revêtement Sol</option>
-              <option value="Enduit"           <%= (query.categorie === 'Enduit')           ? 'selected' : '' %>>Enduit</option>
-              <option value="Maçonnerie"       <%= (query.categorie === 'Maçonnerie')       ? 'selected' : '' %>>Maçonnerie</option>
-              <option value="Ventilation"      <%= (query.categorie === 'Ventilation')      ? 'selected' : '' %>>Ventilation</option>
-              <option value="Menuiserie"       <%= (query.categorie === 'Menuiserie')       ? 'selected' : '' %>>Menuiserie</option>
-              <option value="Electroportatif"  <%= (query.categorie === 'Electroportatif') ? 'selected' : '' %>>Electroportatif</option>
-              <option value="Autre"            <%= (query.categorie === 'Autre')            ? 'selected' : '' %>>Autre</option>
+              <option value="Électricité" <%= (query.categorie === 'Électricité') ? 'selected' : '' %>>Électricité</option>
+              <option value="Plomberie" <%= (query.categorie === 'Plomberie') ? 'selected' : '' %>>Plomberie</option>
+              <option value="CVC" <%= (query.categorie === 'CVC') ? 'selected' : '' %>>CVC</option>
+              <option value="Plâtrerie" <%= (query.categorie === 'Plâtrerie') ? 'selected' : '' %>>Plâtrerie</option>
+              <option value="Menuiserie INT" <%= (query.categorie === 'Menuiserie INT') ? 'selected' : '' %>>Menuiserie INT</option>
+              <option value="Menuiserie EXT" <%= (query.categorie === 'Menuiserie EXT') ? 'selected' : '' %>>Menuiserie EXT</option>
+              <option value="Revêtement de sol" <%= (query.categorie === 'Revêtement de sol') ? 'selected' : '' %>>Revêtement de sol</option>
+              <option value="Revêtement mural" <%= (query.categorie === 'Revêtement mural') ? 'selected' : '' %>>Revêtement mural</option>
+              <option value="Quincaillerie" <%= (query.categorie === 'Quincaillerie') ? 'selected' : '' %>>Quincaillerie</option>
+              <option value="Fixations (visseries, colles…)" <%= (query.categorie === 'Fixations (visseries, colles…)') ? 'selected' : '' %>>Fixations (visseries, colles…)</option>
             </select>
           </div>
 

--- a/views/materiel/editer.ejs
+++ b/views/materiel/editer.ejs
@@ -108,17 +108,17 @@
           <div class="mb-3">
             <label for="categorie" class="form-label">Catégorie</label>
             <select name="categorie" id="categorie" class="form-select" required>
+              <option value="" <%= ['Électricité', 'Plomberie', 'CVC', 'Plâtrerie', 'Menuiserie INT', 'Menuiserie EXT', 'Revêtement de sol', 'Revêtement mural', 'Quincaillerie', 'Fixations (visseries, colles…)'].includes(materiel.categorie) ? '' : 'selected' %>>-- Choisir une catégorie --</option>
+              <option value="Électricité" <%= materiel.categorie === 'Électricité' ? 'selected' : '' %>>Électricité</option>
               <option value="Plomberie" <%= materiel.categorie === 'Plomberie' ? 'selected' : '' %>>Plomberie</option>
-              <option value="Electricité" <%= materiel.categorie === 'Electricité' ? 'selected' : '' %>>Electricité</option>
-              <option value="Climatisation" <%= materiel.categorie === 'Climatisation' ? 'selected' : '' %>>Climatisation</option>
-              <option value="Chauffage" <%= materiel.categorie === 'Chauffage' ? 'selected' : '' %>>Chauffage</option>
-              <option value="Revêtement mural / Revêtement Sol" <%= materiel.categorie === 'Revêtement mural / Revêtement Sol' ? 'selected' : '' %>>Revêtement mural / Revêtement Sol</option>
-              <option value="Enduit" <%= materiel.categorie === 'Enduit' ? 'selected' : '' %>>Enduit</option>
-              <option value="Maçonnerie" <%= materiel.categorie === 'Maçonnerie' ? 'selected' : '' %>>Maçonnerie</option>
-              <option value="Ventilation" <%= materiel.categorie === 'Ventilation' ? 'selected' : '' %>>Ventilation</option>
-              <option value="Menuiserie" <%= materiel.categorie === 'Menuiserie' ? 'selected' : '' %>>Menuiserie</option>
-              <option value="Electroportatif" <%= materiel.categorie === 'Electroportatif' ? 'selected' : '' %>>Electroportatif</option>
-              <option value="Autre" <%= !materiel.categorie || materiel.categorie === 'Autre' ? 'selected' : '' %>>Autre</option>
+              <option value="CVC" <%= materiel.categorie === 'CVC' ? 'selected' : '' %>>CVC</option>
+              <option value="Plâtrerie" <%= materiel.categorie === 'Plâtrerie' ? 'selected' : '' %>>Plâtrerie</option>
+              <option value="Menuiserie INT" <%= materiel.categorie === 'Menuiserie INT' ? 'selected' : '' %>>Menuiserie INT</option>
+              <option value="Menuiserie EXT" <%= materiel.categorie === 'Menuiserie EXT' ? 'selected' : '' %>>Menuiserie EXT</option>
+              <option value="Revêtement de sol" <%= materiel.categorie === 'Revêtement de sol' ? 'selected' : '' %>>Revêtement de sol</option>
+              <option value="Revêtement mural" <%= materiel.categorie === 'Revêtement mural' ? 'selected' : '' %>>Revêtement mural</option>
+              <option value="Quincaillerie" <%= materiel.categorie === 'Quincaillerie' ? 'selected' : '' %>>Quincaillerie</option>
+              <option value="Fixations (visseries, colles…)" <%= materiel.categorie === 'Fixations (visseries, colles…)' ? 'selected' : '' %>>Fixations (visseries, colles…)</option>
             </select>
           </div>
 


### PR DESCRIPTION
## Summary
- replace the matériel creation form category choices with the new ten-category list
- update the dashboard filter to offer the same set of categories
- align the edit view with the unified category options

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cc1b9168c48328bef6fadb094e3f97