### PR TITLE
Ajout des catégories Maçonnerie, Outillage Électroportatif et Autres

### DIFF
--- a/views/materiel/ajouter.ejs
+++ b/views/materiel/ajouter.ejs
@@ -111,10 +111,13 @@
               <option value="Plâtrerie">Plâtrerie</option>
               <option value="Menuiserie INT">Menuiserie INT</option>
               <option value="Menuiserie EXT">Menuiserie EXT</option>
+              <option value="Maçonnerie">Maçonnerie</option>
               <option value="Revêtement de sol">Revêtement de sol</option>
               <option value="Revêtement mural">Revêtement mural</option>
               <option value="Quincaillerie">Quincaillerie</option>
               <option value="Fixations (visseries, colles…)">Fixations (visseries, colles…)</option>
+              <option value="Outillage Électroportatif">Outillage Électroportatif</option>
+              <option value="Autres">Autres</option>
             </select>
           </div>
 

--- a/views/materiel/dashboard.ejs
+++ b/views/materiel/dashboard.ejs
@@ -150,10 +150,13 @@
               <option value="Plâtrerie" <%= (query.categorie === 'Plâtrerie') ? 'selected' : '' %>>Plâtrerie</option>
               <option value="Menuiserie INT" <%= (query.categorie === 'Menuiserie INT') ? 'selected' : '' %>>Menuiserie INT</option>
               <option value="Menuiserie EXT" <%= (query.categorie === 'Menuiserie EXT') ? 'selected' : '' %>>Menuiserie EXT</option>
+              <option value="Maçonnerie" <%= (query.categorie === 'Maçonnerie') ? 'selected' : '' %>>Maçonnerie</option>
               <option value="Revêtement de sol" <%= (query.categorie === 'Revêtement de sol') ? 'selected' : '' %>>Revêtement de sol</option>
               <option value="Revêtement mural" <%= (query.categorie === 'Revêtement mural') ? 'selected' : '' %>>Revêtement mural</option>
               <option value="Quincaillerie" <%= (query.categorie === 'Quincaillerie') ? 'selected' : '' %>>Quincaillerie</option>
               <option value="Fixations (visseries, colles…)" <%= (query.categorie === 'Fixations (visseries, colles…)') ? 'selected' : '' %>>Fixations (visseries, colles…)</option>
+              <option value="Outillage Électroportatif" <%= (query.categorie === 'Outillage Électroportatif') ? 'selected' : '' %>>Outillage Électroportatif</option>
+              <option value="Autres" <%= (query.categorie === 'Autres') ? 'selected' : '' %>>Autres</option>
             </select>
           </div>
 

--- a/views/materiel/editer.ejs
+++ b/views/materiel/editer.ejs
@@ -108,17 +108,20 @@
           <div class="mb-3">
             <label for="categorie" class="form-label">Catégorie</label>
             <select name="categorie" id="categorie" class="form-select" required>
-              <option value="" <%= ['Électricité', 'Plomberie', 'CVC', 'Plâtrerie', 'Menuiserie INT', 'Menuiserie EXT', 'Revêtement de sol', 'Revêtement mural', 'Quincaillerie', 'Fixations (visseries, colles…)'].includes(materiel.categorie) ? '' : 'selected' %>>-- Choisir une catégorie --</option>
+              <option value="" <%= ['Électricité', 'Plomberie', 'CVC', 'Plâtrerie', 'Menuiserie INT', 'Menuiserie EXT', 'Maçonnerie', 'Revêtement de sol', 'Revêtement mural', 'Quincaillerie', 'Fixations (visseries, colles…)', 'Outillage Électroportatif', 'Autres'].includes(materiel.categorie) ? '' : 'selected' %>>-- Choisir une catégorie --</option>
               <option value="Électricité" <%= materiel.categorie === 'Électricité' ? 'selected' : '' %>>Électricité</option>
               <option value="Plomberie" <%= materiel.categorie === 'Plomberie' ? 'selected' : '' %>>Plomberie</option>
               <option value="CVC" <%= materiel.categorie === 'CVC' ? 'selected' : '' %>>CVC</option>
               <option value="Plâtrerie" <%= materiel.categorie === 'Plâtrerie' ? 'selected' : '' %>>Plâtrerie</option>
               <option value="Menuiserie INT" <%= materiel.categorie === 'Menuiserie INT' ? 'selected' : '' %>>Menuiserie INT</option>
               <option value="Menuiserie EXT" <%= materiel.categorie === 'Menuiserie EXT' ? 'selected' : '' %>>Menuiserie EXT</option>
+              <option value="Maçonnerie" <%= materiel.categorie === 'Maçonnerie' ? 'selected' : '' %>>Maçonnerie</option>
               <option value="Revêtement de sol" <%= materiel.categorie === 'Revêtement de sol' ? 'selected' : '' %>>Revêtement de sol</option>
               <option value="Revêtement mural" <%= materiel.categorie === 'Revêtement mural' ? 'selected' : '' %>>Revêtement mural</option>
               <option value="Quincaillerie" <%= materiel.categorie === 'Quincaillerie' ? 'selected' : '' %>>Quincaillerie</option>
               <option value="Fixations (visseries, colles…)" <%= materiel.categorie === 'Fixations (visseries, colles…)' ? 'selected' : '' %>>Fixations (visseries, colles…)</option>
+              <option value="Outillage Électroportatif" <%= materiel.categorie === 'Outillage Électroportatif' ? 'selected' : '' %>>Outillage Électroportatif</option>
+              <option value="Autres" <%= materiel.categorie === 'Autres' ? 'selected' : '' %>>Autres</option>
             </select>
           </div>
 


### PR DESCRIPTION
## Summary
- ajouter les catégories Maçonnerie, Outillage Électroportatif et Autres dans le formulaire d'ajout de matériel
- proposer les mêmes catégories dans le filtre du tableau de bord du stock
- permettre de sélectionner ces catégories lors de l'édition d'un matériel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cd1ee78c408328b5398c7827cb7799