### PR TITLE
Add reset filter link on stock dashboard

### DIFF
--- a/views/materiel/dashboard.ejs
+++ b/views/materiel/dashboard.ejs
@@ -276,6 +276,11 @@
             <button type="submit" class="btn btn-primary w-100">Rechercher</button>
           </div>
 
+          <!-- Bouton Réinitialiser -->
+          <div class="col-md-2 align-self-end">
+            <a href="/materiel" class="btn btn-outline-secondary w-100">Réinitialiser</a>
+          </div>
+
           <div class="col-md-2 align-self-end">
             <a href="/materiel/scanner" class="btn btn-info">Scanner QR/Code-barres</a>
 


### PR DESCRIPTION
## Summary
- add a reset button in the stock dashboard filter form to quickly clear all criteria

## Testing
- npm run test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68cd2b4627448328aaaa9c289b6e5bcb