### PR TITLE
Add Zone Sécu rack type to matériel views

### DIFF
--- a/views/materiel/ajouter.ejs
+++ b/views/materiel/ajouter.ejs
@@ -147,6 +147,7 @@
               <option value="RM10">RM10</option>
               <option value="GL">GL</option>
               <option value="RK">RK</option>
+              <option value="ZS">Zone Sécu (ZS)</option>
               <option value="Mezza">Mezza</option>
               <option value="Contenaire">Contenaire</option>
             </select>
@@ -275,6 +276,17 @@
           compartimentGroup.style.display = 'block';
           populate(niveauSelect, ['0', '1', '2', '3']);
           niveauGroup.style.display = 'block';
+          break;
+        }
+        case 'ZS': {
+          const letters = Array.from({ length: 6 }, (_, i) =>
+            String.fromCharCode('A'.charCodeAt(0) + i)
+          );
+          populate(compartimentSelect, letters);
+          compartimentGroup.style.display = 'block';
+          populate(niveauSelect, ['0', '1', '2', '3', '4']);
+          niveauGroup.style.display = 'block';
+          positionGroup.style.display = 'none';
           break;
         }
         case 'Mezza':

--- a/views/materiel/dashboard.ejs
+++ b/views/materiel/dashboard.ejs
@@ -178,6 +178,7 @@
               <option value="RM10" <%= (query.rack === 'RM10') ? 'selected' : '' %>>RM10</option>
               <option value="GL" <%= (query.rack === 'GL') ? 'selected' : '' %>>GL</option>
               <option value="RK" <%= (query.rack === 'RK') ? 'selected' : '' %>>RK</option>
+              <option value="ZS" <%= (query.rack === 'ZS') ? 'selected' : '' %>>Zone Sécu (ZS)</option>
               <option value="Mezza" <%= (query.rack === 'Mezza') ? 'selected' : '' %>>Mezza</option>
               <option value="Contenaire" <%= (query.rack === 'Contenaire') ? 'selected' : '' %>>Contenaire</option>
               <option value="A"   <%= (query.rack === 'A')   ? 'selected' : '' %>>A</option>

--- a/views/materiel/editer.ejs
+++ b/views/materiel/editer.ejs
@@ -151,6 +151,7 @@
               <option value="RM10" <%= materiel.rack === 'RM10' ? 'selected' : '' %>>RM10</option>
               <option value="GL" <%= materiel.rack === 'GL' ? 'selected' : '' %>>GL</option>
               <option value="RK" <%= materiel.rack === 'RK' ? 'selected' : '' %>>RK</option>
+              <option value="ZS" <%= materiel.rack === 'ZS' ? 'selected' : '' %>>Zone Sécu (ZS)</option>
               <option value="Mezza" <%= materiel.rack === 'Mezza' ? 'selected' : '' %>>Mezza</option>
               <option value="Contenaire" <%= materiel.rack === 'Contenaire' ? 'selected' : '' %>>Contenaire</option>
             </select>
@@ -299,6 +300,17 @@
           compartimentGroup.style.display = 'block';
           populate(niveauSelect, ['0', '1', '2', '3']);
           niveauGroup.style.display = 'block';
+          break;
+        }
+        case 'ZS': {
+          const letters = Array.from({ length: 6 }, (_, i) =>
+            String.fromCharCode('A'.charCodeAt(0) + i)
+          );
+          populate(compartimentSelect, letters);
+          compartimentGroup.style.display = 'block';
+          populate(niveauSelect, ['0', '1', '2', '3', '4']);
+          niveauGroup.style.display = 'block';
+          positionGroup.style.display = 'none';
           break;
         }
         case 'Mezza':


### PR DESCRIPTION
## Summary
- add the Zone Sécu (ZS) rack option to the matériel create/edit forms and dashboard filter
- update dynamic field logic so ZS racks expose compartments A–F, levels 0–4 and hide position selectors

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68ce7989ff708328bf7cf58cef01b66b