### PR TITLE
Add chantier reception workflow with email alerts

### DIFF
--- a/utils/mailer.js
+++ b/utils/mailer.js
@@ -25,4 +25,31 @@ async function sendLowStockNotification(materiel) {
   }
 }
 
-module.exports = { sendLowStockNotification };
+async function sendReceptionGapNotification({ difference, materielNom, chantierNom }) {
+  const recipients = [
+    'launay.jeremy@batirenov.info',
+    'athari.keivan@batirenov.info',
+    'blot.valentin@batirenov.info',
+    'rouault.christophe@batirenov.info',
+    'mirona.orian@batirenov.info'
+  ];
+
+  const mailOptions = {
+    from: process.env.EMAIL_USER,
+    to: recipients.join(','),
+    subject: `Manque de réception pour ${materielNom}`,
+    text: [
+      `Attention il manque ${difference} à réceptionner pour ${materielNom}.`,
+      `Chantier concerné : ${chantierNom}.`
+    ].join('\n')
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log(`Alerte de réception envoyée pour ${materielNom} (${chantierNom})`);
+  } catch (error) {
+    console.error("Erreur lors de l'envoi de l'alerte de réception :", error);
+  }
+}
+
+module.exports = { sendLowStockNotification, sendReceptionGapNotification };

--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -335,6 +335,35 @@
               <td>
 
                 <% if (user && user.role === 'admin') { %>
+                <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#receptionModal<%= mc.id %>">
+                  Réceptionner
+                </button>
+
+                <div class="modal fade" id="receptionModal<%= mc.id %>" tabindex="-1" aria-labelledby="receptionModalLabel<%= mc.id %>" aria-hidden="true">
+                  <div class="modal-dialog">
+                    <div class="modal-content">
+                      <form action="/chantier/materielChantier/receptionner/<%= mc.id %>" method="POST">
+                        <div class="modal-header bg-success text-white">
+                          <h5 class="modal-title" id="receptionModalLabel<%= mc.id %>">Réceptionner du matériel</h5>
+                          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+                        </div>
+                        <div class="modal-body">
+                          <p class="mb-2"><strong>Matériel :</strong> <%= mc.materiel ? mc.materiel.nom : 'N/A' %></p>
+                          <p class="mb-3"><strong>Chantier :</strong> <%= mc.chantier ? mc.chantier.nom : 'N/A' %></p>
+                          <div class="mb-3">
+                            <label for="quantiteReceptionnee<%= mc.id %>" class="form-label">Quantité réceptionnée</label>
+                            <input type="number" class="form-control" id="quantiteReceptionnee<%= mc.id %>" name="quantiteReceptionnee" min="1" required>
+                          </div>
+                        </div>
+                        <div class="modal-footer">
+                          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                          <button type="submit" class="btn btn-success">Confirmer</button>
+                        </div>
+                      </form>
+                    </div>
+                  </div>
+                </div>
+
                 <!-- Bouton ici -->
                  <a href="/chantier/materielChantier/modifier/<%= mc.id %>" class="btn btn-warning btn-sm">Modifier</a>
                 <!-- Tu peux aussi ajouter un bouton pour supprimer ici -->


### PR DESCRIPTION
## Summary
- add a reception modal to chantier inventory rows so admins can record the received quantity
- update the chantier route to apply the reception changes, log the operation, and email stakeholders if reception shortfalls remain
- extend the mailer utility with a helper dedicated to chantier reception gap notifications

## Testing
- node --check routes/chantier.js
- node --check utils/mailer.js
- npm start *(fails: sqlite3 dependency missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68da941b2348832883af5163819012ad