### PR TITLE
Handle reception email alerts on quantity mismatch

### DIFF
--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -200,6 +200,7 @@ router.post('/materielChantier/receptionner/:id', ensureAuthenticated, checkAdmi
 
     const oldQuantite = mc.quantite || 0;
     const oldQuantitePrevue = mc.quantitePrevue ?? 0;
+    const quantitePrevueTotale = oldQuantite + oldQuantitePrevue;
 
     const newQuantite = oldQuantite + receptionQty;
     const newQuantitePrevue = Math.max(oldQuantitePrevue - receptionQty, 0);
@@ -220,13 +221,15 @@ router.post('/materielChantier/receptionner/:id', ensureAuthenticated, checkAdmi
       stockType: 'chantier'
     });
 
-    const difference = (mc.quantitePrevue ?? 0) - mc.quantite;
+    const difference = newQuantite - quantitePrevueTotale;
 
-    if (difference > 0 && mc.materiel && mc.chantier) {
+    if (difference !== 0 && mc.materiel && mc.chantier) {
       await sendReceptionGapNotification({
         difference,
         materielNom: mc.materiel.nom,
-        chantierNom: mc.chantier.nom
+        chantierNom: mc.chantier.nom,
+        quantitePrevue: quantitePrevueTotale,
+        quantiteReelle: newQuantite
       });
     }
 

--- a/utils/mailer.js
+++ b/utils/mailer.js
@@ -25,7 +25,13 @@ async function sendLowStockNotification(materiel) {
   }
 }
 
-async function sendReceptionGapNotification({ difference, materielNom, chantierNom }) {
+async function sendReceptionGapNotification({
+  difference,
+  materielNom,
+  chantierNom,
+  quantitePrevue,
+  quantiteReelle
+}) {
   const recipients = [
     'launay.jeremy@batirenov.info',
     'athari.keivan@batirenov.info',
@@ -34,12 +40,18 @@ async function sendReceptionGapNotification({ difference, materielNom, chantierN
     'mirona.orian@batirenov.info'
   ];
 
+  const ecartAbsolu = Math.abs(difference);
+  const tendance = difference > 0 ? 'supérieure' : 'inférieure';
+
   const mailOptions = {
     from: process.env.EMAIL_USER,
     to: recipients.join(','),
-    subject: `Manque de réception pour ${materielNom}`,
+    subject: `Écart de réception pour ${materielNom}`,
     text: [
-      `Attention il manque ${difference} à réceptionner pour ${materielNom}.`,
+      `Une différence de ${ecartAbsolu} a été détectée entre la quantité prévue et la quantité réceptionnée pour ${materielNom}.`,
+      `La quantité réceptionnée est ${tendance} à la quantité prévue.`,
+      `Quantité prévue : ${quantitePrevue}.`,
+      `Quantité réceptionnée : ${quantiteReelle}.`,
       `Chantier concerné : ${chantierNom}.`
     ].join('\n')
   };


### PR DESCRIPTION
## Summary
- trigger the chantier reception notification whenever the received quantity differs from the planned quantity
- enrich the reception notification email with both expected and received quantities so the gap is explicit

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68da99a674bc832888777116ad08eab0