### PR TITLE
Préselection automatique du chantier lors de l'ajout de matériel

### DIFF
--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -247,25 +247,31 @@ router.get('/ajouterMateriel', ensureAuthenticated, checkAdmin, async (req, res)
     const chantiers = await Chantier.findAll();
     const emplacementsBruts = await Emplacement.findAll({ include: [{ model: Emplacement, as: 'parent' }] });
     const categories = await loadCategories();
+    const { chantierId: selectedChantierId } = req.query;
 
-function construireCheminComplet(emplacement) {
-  let chemin = emplacement.nom;
-  let courant = emplacement.parent;
-  while (courant) {
-    chemin = `${courant.nom} > ${chemin}`;
-    courant = courant.parent;
-  }
-  return chemin;
-}
+    function construireCheminComplet(emplacement) {
+      let chemin = emplacement.nom;
+      let courant = emplacement.parent;
+      while (courant) {
+        chemin = `${courant.nom} > ${chemin}`;
+        courant = courant.parent;
+      }
+      return chemin;
+    }
 
-const emplacements = emplacementsBruts.map(e => ({
-  id: e.id,
-  cheminComplet: construireCheminComplet(e),
-  chantierId: e.chantierId
-}));
+    const emplacements = emplacementsBruts.map(e => ({
+      id: e.id,
+      cheminComplet: construireCheminComplet(e),
+      chantierId: e.chantierId
+    }));
 
     // On passe chantiers et emplacements en une seule réponse
-    res.render('chantier/ajouterMateriel', { chantiers, emplacements, categories });
+    res.render('chantier/ajouterMateriel', {
+      chantiers,
+      emplacements,
+      categories,
+      selectedChantierId: selectedChantierId || ''
+    });
   } catch (err) {
     console.error(err);
     res.send("Erreur lors du chargement du formulaire d'ajout de matériel dans un chantier.");

--- a/views/chantier/ajouterMateriel.ejs
+++ b/views/chantier/ajouterMateriel.ejs
@@ -255,9 +255,9 @@ select#emplacementId.form-control {
       <div class="mb-3">
         <label for="chantierId" class="form-label">Chantier</label>
         <select name="chantierId" id="chantierId" class="form-control" required>
-          <option value="" disabled selected>-- Choisir un chantier --</option>
+          <option value="" disabled <%= selectedChantierId ? '' : 'selected' %>>-- Choisir un chantier --</option>
           <% chantiers.forEach(function(c){ %>
-            <option value="<%= c.id %>">
+            <option value="<%= c.id %>" <%= String(c.id) === String(selectedChantierId) ? 'selected' : '' %>>
               <%= c.nom %> - <%= c.localisation %>
             </option>
           <% }); %>

--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -79,7 +79,13 @@
   <% if (user && user.role === 'admin') { %>
   <!-- Bouton ici -->
    <!-- <a href="/chantier/ajouter" class="btn btn-primary">Ajouter une livraison chantier</a>-->
-  <a href="/chantier/ajouterMateriel" class="btn btn-success">Ajouter du matériel dans un chantier</a>
+  <% const chantierSelectionne = (chantiers || []).find(c => String(c.id) === String(chantierId)); %>
+  <a
+    href="/chantier/ajouterMateriel<%= chantierSelectionne ? `?chantierId=${encodeURIComponent(chantierSelectionne.id)}` : '' %>"
+    class="btn btn-success"
+  >
+    Ajouter du matériel dans <%= chantierSelectionne ? `chantier &laquo; ${chantierSelectionne.nom} &raquo;` : 'un chantier' %>
+  </a>
   <!-- Supprime le bouton "Modifier" global ici -->
   <a href="/chantier/ajouter-chantier" class="btn btn-success">Créer un nouveau chantier</a>
   <a href="/chantier/historique" class="btn btn-warning">Voir l'historique chantier</a>


### PR DESCRIPTION
## Summary
- adapte le libellé du bouton d’ajout de matériel pour afficher le chantier filtré et transmettre sa sélection
- fait suivre l’identifiant de chantier au formulaire d’ajout direct afin de présélectionner le chantier correspondant
- prépare la vue d’ajout de matériel pour marquer automatiquement le chantier reçu dans la requête

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68da9f6df3c883289618a96c1ef8e418