### PR TITLE
Add supplier filter to chantier stock view

### DIFF
--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -103,6 +103,7 @@
     pushParam('categorie', categorie);
     pushParam('emplacement', emplacement);
     pushParam('description', description);
+    pushParam('fournisseur', fournisseur);
     pushParam('triNom', triNom);
     pushParam('triAjout', triAjout);
     pushParam('triModification', triModification);
@@ -183,6 +184,16 @@
         <option value="<%= e.nom %>" <%= emplacement === e.nom ? 'selected' : '' %>><%= e.nom %></option>
       <% }); %>
     <% } %>
+  </select>
+</div>
+
+<div class="col-md-3">
+  <label for="fournisseur" class="form-label">Fournisseur</label>
+  <select class="form-select" name="fournisseur" id="fournisseur">
+    <option value="">-- Tous les fournisseurs --</option>
+    <% (fournisseurs || []).forEach(function(f) { %>
+      <option value="<%= f %>" <%= fournisseur === f ? 'selected' : '' %>><%= f %></option>
+    <% }); %>
   </select>
 </div>
 


### PR DESCRIPTION
## Summary
- add supplier to the chantier stock filter keys and query handling
- surface the list of existing suppliers and expose it in the chantier inventory form
- ensure supplier selection is preserved for exports and filtering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dbb070ae108328bfdb47efbc937879