### PR TITLE
Add info view for depot materials

### DIFF
--- a/routes/materiel.js
+++ b/routes/materiel.js
@@ -11,6 +11,7 @@ const Materiel = require('../models/Materiel');
 const Photo = require('../models/Photo');
 const Historique = require('../models/Historique');
 const User = require('../models/User');
+const Emplacement = require('../models/Emplacement');
 const MaterielDelivery = require('../models/MaterielDelivery'); // si utilisé
 const { sendLowStockNotification } = require('../utils/mailer') || {};
 
@@ -609,6 +610,35 @@ router.get('/historique', ensureAuthenticated, checkAdmin, async (req, res) => {
   } catch (err) {
     console.error("Erreur lors de la récupération de l'historique du dépôt :", err);
     res.send("Erreur lors de la récupération de l'historique du dépôt.");
+  }
+});
+
+/* ======================
+   FICHE D'UN MATÉRIEL (DÉPÔT)
+====================== */
+router.get('/info/:id', ensureAuthenticated, async (req, res) => {
+  try {
+    const materiel = await Materiel.findByPk(req.params.id, {
+      include: [
+        { model: Photo, as: 'photos' },
+        { model: Emplacement, as: 'emplacement' }
+      ]
+    });
+
+    if (!materiel) {
+      return res.status(404).send("Matériel non trouvé.");
+    }
+
+    const historique = await Historique.findAll({
+      where: { materielId: materiel.id },
+      include: [{ model: User, as: 'user' }],
+      order: [['createdAt', 'DESC']]
+    });
+
+    res.render('materiel/infoMaterielDepot', { materiel, historique });
+  } catch (err) {
+    console.error('Erreur lors de la récupération des informations du matériel dépôt :', err);
+    res.send("Erreur lors de la récupération des informations du matériel.");
   }
 });
 

--- a/views/materiel/dashboard.ejs
+++ b/views/materiel/dashboard.ejs
@@ -381,15 +381,16 @@
                       <% } %>
                   </td>
                   <td>
-                    <% if (user && user.role === 'admin') { %>
-                      <a href="/materiel/editer/<%= m.id %>" class="btn btn-primary btn-sm mb-1 me-1">Modifier</a>
-                      <a href="/materiel/modifier/<%= m.id %>" class="btn btn-warning btn-sm mb-1">Modifier Quantité</a>
-                      <form action="/materiel/supprimer/<%= m.id %>" method="POST" style="display:inline-block;" onsubmit="return confirm('Voulez-vous vraiment supprimer ce matériel ?');">
-                        <button type="submit" class="btn btn-danger btn-sm">Supprimer</button>
-                      </form>
-                    <% } else { %>
-                      <span class="text-muted">Aucune action</span>
-                    <% } %>
+                    <div class="d-flex flex-wrap gap-1">
+                      <a href="/materiel/info/<%= m.id %>" class="btn btn-info btn-sm mb-1">Info</a>
+                      <% if (user && user.role === 'admin') { %>
+                        <a href="/materiel/editer/<%= m.id %>" class="btn btn-primary btn-sm mb-1">Modifier</a>
+                        <a href="/materiel/modifier/<%= m.id %>" class="btn btn-warning btn-sm mb-1">Modifier Quantité</a>
+                        <form action="/materiel/supprimer/<%= m.id %>" method="POST" class="mb-1" onsubmit="return confirm('Voulez-vous vraiment supprimer ce matériel ?');">
+                          <button type="submit" class="btn btn-danger btn-sm">Supprimer</button>
+                        </form>
+                      <% } %>
+                    </div>
                   </td>
                 </tr>
               <% }) %>
@@ -423,13 +424,16 @@
               <% } else { %>Aucune<% } %>
           </li>
         </ul>
-        <% if (user && user.role==='admin') { %>
-          <a href="/materiel/editer/<%=m.id%>" class="btn btn-sm btn-primary mb-1">Modifier</a>
-          <a href="/materiel/modifier/<%=m.id%>" class="btn btn-sm btn-warning mb-1">Modifier Quantité</a>
-          <form action="/materiel/supprimer/<%=m.id%>" method="POST" style="display:inline;">
-            <button class="btn btn-sm btn-danger">Supprimer</button>
-          </form>
-        <% } %>
+        <div class="mt-3 d-flex flex-wrap gap-2">
+          <a href="/materiel/info/<%= m.id %>" class="btn btn-sm btn-info">Info</a>
+          <% if (user && user.role==='admin') { %>
+            <a href="/materiel/editer/<%=m.id%>" class="btn btn-sm btn-primary">Modifier</a>
+            <a href="/materiel/modifier/<%=m.id%>" class="btn btn-sm btn-warning">Modifier Quantité</a>
+            <form action="/materiel/supprimer/<%=m.id%>" method="POST">
+              <button class="btn btn-sm btn-danger" onclick="return confirm('Voulez-vous vraiment supprimer ce matériel ?');">Supprimer</button>
+            </form>
+          <% } %>
+        </div>
       </div>
     </div>
   <% }) %>

--- a/views/materiel/infoMaterielDepot.ejs
+++ b/views/materiel/infoMaterielDepot.ejs
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Fiche du matériel dépôt</title>
+  <link rel="stylesheet" href="/css/bootstrap.min.css">
+  <style>
+    body {
+      background-color: #f8f9fa;
+    }
+    .card {
+      border-left: 5px solid #0d6efd;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+    }
+    .card img {
+      max-width: 100%;
+      border-radius: 5px;
+      margin-top: 10px;
+      box-shadow: 0 0 5px rgba(0,0,0,0.2);
+    }
+    .table th {
+      background-color: #e9ecef;
+    }
+    .badge-action {
+      font-size: 0.85em;
+    }
+  </style>
+</head>
+<body>
+  <%
+    const formatQuantity = value => Number(value ?? 0).toLocaleString('fr-FR', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
+    });
+    const formatPrice = value => {
+      if (value === null || value === undefined || value === '') {
+        return '-';
+      }
+      const number = Number(value);
+      if (Number.isNaN(number)) {
+        return value;
+      }
+      return number.toLocaleString('fr-FR', { style: 'currency', currency: 'EUR' });
+    };
+  %>
+  <div class="container mt-5">
+    <h2 class="mb-4 text-primary">🔍 Détails du matériel : <%= materiel.nom %></h2>
+
+    <div class="card mb-4">
+      <div class="card-body">
+        <p><strong>📦 Référence :</strong> <%= materiel.reference || '-' %></p>
+        <p><strong>📝 Description :</strong> <%= materiel.description || '-' %></p>
+        <p><strong>🏷️ Catégorie :</strong> <%= materiel.categorie || '-' %></p>
+        <p><strong>🏢 Fournisseur :</strong> <%= materiel.fournisseur || '-' %></p>
+        <p><strong>💰 Prix :</strong> <%= formatPrice(materiel.prix) %></p>
+        <p><strong>🔢 Quantité en stock :</strong> <%= formatQuantity(materiel.quantite) %></p>
+        <p><strong>📍 Emplacement :</strong> <%= materiel.emplacement ? materiel.emplacement.nom : '-' %></p>
+        <p><strong>📦 Rack :</strong> <%= materiel.rack || '-' %></p>
+        <p><strong>🗃️ Compartiment :</strong> <%= materiel.compartiment || '-' %></p>
+        <p><strong>📐 Niveau :</strong> <%= (materiel.niveau !== null && materiel.niveau !== undefined) ? materiel.niveau : '-' %></p>
+        <p><strong>🎯 Position :</strong> <%= materiel.position || '-' %></p>
+
+        <% if (materiel.photos && materiel.photos.length > 0) { %>
+          <p><strong>🖼️ Photos :</strong></p>
+          <div class="d-flex flex-wrap gap-2">
+            <% materiel.photos.forEach(photo => { %>
+              <a href="/<%= photo.chemin.replace(/\\/g, '/') %>" target="_blank">
+                <img src="/<%= photo.chemin.replace(/\\/g, '/') %>" alt="Photo de <%= materiel.nom %>" class="img-fluid" style="max-width: 200px;">
+              </a>
+            <% }) %>
+          </div>
+        <% } else { %>
+          <p><strong>🖼️ Photos :</strong> -</p>
+        <% } %>
+      </div>
+    </div>
+
+    <h4 class="text-secondary">🕓 Historique des actions</h4>
+    <% if (!historique || historique.length === 0) { %>
+      <p class="text-muted">Aucune action enregistrée.</p>
+    <% } else { %>
+      <table class="table table-hover table-sm mt-3">
+        <thead>
+          <tr>
+            <th>Date / Heure</th>
+            <th>Action</th>
+            <th>Par</th>
+            <th>Ancienne Qte</th>
+            <th>Nouvelle Qte</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% historique.forEach(h => { %>
+            <tr>
+              <td><%= new Date(h.createdAt).toLocaleString('fr-FR') %></td>
+              <td><span class="badge bg-info text-dark badge-action"><%= h.action %></span></td>
+              <td><%= h.user ? h.user.nom : 'Inconnu' %></td>
+              <td><%= (h.oldQuantite !== null && h.oldQuantite !== undefined) ? formatQuantity(h.oldQuantite) : '-' %></td>
+              <td><%= (h.newQuantite !== null && h.newQuantite !== undefined) ? formatQuantity(h.newQuantite) : '-' %></td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    <% } %>
+
+    <a href="/materiel" class="btn btn-outline-secondary mt-4">⬅ Retour au stock dépôt</a>
+  </div>
+
+  <script src="/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expose a depot material detail route with history and photo data
- create a dedicated depot material detail page mirroring the chantier info layout
- surface the Info action on the depot dashboard for desktop and mobile views

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dd39835ab883288e2ca3a6c4c8f7c4