### PR TITLE
Fix chantier transfer material mapping and remove duplicate user route

### DIFF
--- a/app.js
+++ b/app.js
@@ -73,7 +73,21 @@ app.use((req, res, next) => {
 app.use(setCrossOriginHeaders);
 
 // Base de données Sequelize + modèles supplémentaires
-const { sequelize } = require('./models');
+const { sequelize, Chantier } = require('./models');
+
+app.use(async (req, res, next) => {
+  if (Array.isArray(res.locals.chantiers) && res.locals.chantiers.length > 0) {
+    return next();
+  }
+
+  try {
+    res.locals.chantiers = await Chantier.findAll({ order: [['nom', 'ASC']] });
+  } catch (error) {
+    console.error(error);
+  }
+
+  next();
+});
 
 
 
@@ -110,12 +124,13 @@ app.use('/vehicule', require('./routes/vehicule'));
 app.use('/bonLivraison', require('./routes/bonLivraison'));
 app.use('/chantier', require('./routes/chantier'));
 //app.use('/materielChantier', require('./routes/materielChantier')); // ← MANQUAIT
- app.use('/emplacements', require('./routes/emplacements'));
+app.use('/emplacements', require('./routes/emplacements'));
+
+app.use('/transferts', require('./routes/transferts'));
  
 
-  const userRoutes = require('./routes/user');
-  app.use('/user', userRoutes);
-app.use('/user', require('./routes/user'));
+const userRoutes = require('./routes/user');
+app.use('/user', userRoutes);
 
 // Lancement du serveur
 const PORT = process.env.PORT || 3000;

--- a/routes/transferts.js
+++ b/routes/transferts.js
@@ -1,0 +1,56 @@
+const express = require('express');
+const router = express.Router();
+
+const { transferParNom } = require('../services/transfertService');
+
+const buildContext = ({ contextType, contextChantierId }) => {
+  const type = contextType === 'CHANTIER' ? 'CHANTIER' : 'DEPOT';
+  if (type === 'CHANTIER') {
+    return { type, chantierId: contextChantierId };
+  }
+  return { type };
+};
+
+const sendFlash = (req, type, message) => {
+  if (typeof req.flash === 'function') {
+    req.flash(type, message);
+  }
+};
+
+router.post('/:action(entree|sortie)', async (req, res) => {
+  const { action } = req.params;
+  const {
+    contextType,
+    contextChantierId,
+    materielId,
+    materielName,
+    targetChantierId,
+    quantite
+  } = req.body;
+
+  const context = buildContext({ contextType, contextChantierId });
+
+  try {
+    const summary = await transferParNom({
+      action: action.toUpperCase(),
+      context,
+      current: {
+        materielId,
+        materielName
+      },
+      targetChantierId,
+      qty: quantite,
+      userId: req.user ? req.user.id : null
+    });
+
+    const message = `${action === 'entree' ? 'Entrée' : 'Sortie'} réalisée avec succès.`;
+    sendFlash(req, 'success', message);
+    res.redirect(req.get('referer') || '/');
+  } catch (error) {
+    console.error(error);
+    sendFlash(req, 'error', error.message || 'Une erreur est survenue lors du transfert.');
+    res.redirect(req.get('referer') || '/');
+  }
+});
+
+module.exports = router;

--- a/services/transfertService.js
+++ b/services/transfertService.js
@@ -1,0 +1,222 @@
+const { sequelize, Materiel, Chantier } = require('../models');
+
+const VALID_ACTIONS = new Set(['ENTREE', 'SORTIE']);
+
+const METADATA_FIELDS = [
+  'reference',
+  'description',
+  'prix',
+  'categorie',
+  'fournisseur',
+  'rack',
+  'compartiment',
+  'niveau',
+  'position',
+  'vehiculeId',
+  'emplacementId'
+];
+
+const parseQuantity = value => {
+  if (typeof value === 'string') {
+    const normalized = value.replace(/,/g, '.').trim();
+    if (normalized === '') return NaN;
+    return Number.parseFloat(normalized);
+  }
+  return Number.parseFloat(value);
+};
+
+const normalizeId = value => {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+function copyMetadata(from) {
+  return METADATA_FIELDS.reduce((acc, field) => {
+    acc[field] = from[field];
+    return acc;
+  }, {});
+}
+
+async function ensureChantierExists(chantierId, transaction) {
+  if (chantierId === null) {
+    return null;
+  }
+  const chantier = await Chantier.findByPk(chantierId, { transaction });
+  if (!chantier) {
+    throw new Error('Chantier sélectionné introuvable.');
+  }
+  return chantier;
+}
+
+async function transferParNom({ action, context, current, targetChantierId, qty, userId }) {
+  const normalizedAction = typeof action === 'string' ? action.toUpperCase() : action;
+  if (!VALID_ACTIONS.has(normalizedAction)) {
+    throw new Error('Action de transfert invalide.');
+  }
+
+  if (!current || !current.materielId || !current.materielName) {
+    throw new Error('Matériel courant invalide.');
+  }
+
+  const quantity = parseQuantity(qty);
+  if (!Number.isFinite(quantity) || quantity <= 0) {
+    throw new Error('Quantité invalide.');
+  }
+
+  const contextType = context && context.type === 'CHANTIER' ? 'CHANTIER' : 'DEPOT';
+  const contextChantierId = contextType === 'CHANTIER' ? normalizeId(context.chantierId) : null;
+
+  if (contextType === 'CHANTIER' && contextChantierId === null) {
+    throw new Error('Chantier courant invalide.');
+  }
+
+  const targetId = normalizeId(targetChantierId);
+
+  const transaction = await sequelize.transaction();
+
+  try {
+    const currentMaterial = await Materiel.findByPk(current.materielId, {
+      transaction,
+      lock: transaction.LOCK.UPDATE
+    });
+
+    if (!currentMaterial && normalizedAction === 'SORTIE') {
+      throw new Error('Matériel source introuvable.');
+    }
+
+    let destinationMaterial = null;
+    let sourceMaterial = null;
+
+    if (normalizedAction === 'ENTREE') {
+      if (targetId === null) {
+        throw new Error('Chantier source requis pour une entrée.');
+      }
+
+      if (contextType === 'CHANTIER' && targetId === contextChantierId) {
+        throw new Error('Impossible de transférer vers le même chantier.');
+      }
+
+      await ensureChantierExists(targetId, transaction);
+
+      sourceMaterial = await Materiel.findOne({
+        where: { nom: current.materielName, chantierId: targetId },
+        transaction,
+        lock: transaction.LOCK.UPDATE
+      });
+
+      if (!sourceMaterial) {
+        throw new Error('Matériel introuvable dans le chantier source.');
+      }
+
+      const available = Number.parseFloat(sourceMaterial.quantite);
+      if (!Number.isFinite(available) || available < quantity) {
+        throw new Error('Quantité insuffisante dans le chantier source.');
+      }
+
+      if (currentMaterial && currentMaterial.nom === current.materielName && currentMaterial.chantierId === contextChantierId) {
+        destinationMaterial = currentMaterial;
+      } else {
+        destinationMaterial = await Materiel.findOne({
+          where: { nom: current.materielName, chantierId: contextChantierId },
+          transaction,
+          lock: transaction.LOCK.UPDATE
+        });
+      }
+
+      if (!destinationMaterial) {
+        const template = currentMaterial || sourceMaterial;
+        const newMaterialPayload = {
+          nom: current.materielName,
+          chantierId: contextChantierId,
+          quantite: 0,
+          ...copyMetadata(template)
+        };
+        destinationMaterial = await Materiel.create(newMaterialPayload, { transaction });
+      }
+
+      sourceMaterial.quantite = available - quantity;
+      const destQty = Number.parseFloat(destinationMaterial.quantite) || 0;
+      destinationMaterial.quantite = destQty + quantity;
+
+      await sourceMaterial.save({ transaction });
+      await destinationMaterial.save({ transaction });
+    } else {
+      // SORTIE
+      if (contextType === 'CHANTIER' && contextChantierId === null) {
+        throw new Error('Chantier source invalide.');
+      }
+
+      sourceMaterial = currentMaterial;
+      if (!sourceMaterial || sourceMaterial.nom !== current.materielName) {
+        throw new Error('Matériel source invalide.');
+      }
+
+      const sourceQty = Number.parseFloat(sourceMaterial.quantite);
+      if (!Number.isFinite(sourceQty) || sourceQty < quantity) {
+        throw new Error('Quantité insuffisante dans la source.');
+      }
+
+      if (targetId === null) {
+        throw new Error('Chantier destination requis.');
+      }
+
+      if (contextType === 'CHANTIER' && targetId === contextChantierId) {
+        throw new Error('Impossible de transférer vers le même chantier.');
+      }
+
+      await ensureChantierExists(targetId, transaction);
+
+      destinationMaterial = await Materiel.findOne({
+        where: { nom: current.materielName, chantierId: targetId },
+        transaction,
+        lock: transaction.LOCK.UPDATE
+      });
+
+      if (!destinationMaterial) {
+        const template = sourceMaterial;
+        const newMaterialPayload = {
+          nom: current.materielName,
+          chantierId: targetId,
+          quantite: 0,
+          ...copyMetadata(template)
+        };
+        destinationMaterial = await Materiel.create(newMaterialPayload, { transaction });
+      }
+
+      sourceMaterial.quantite = sourceQty - quantity;
+      const destQty = Number.parseFloat(destinationMaterial.quantite) || 0;
+      destinationMaterial.quantite = destQty + quantity;
+
+      await sourceMaterial.save({ transaction });
+      await destinationMaterial.save({ transaction });
+    }
+
+    const summary = {
+      from: {
+        id: sourceMaterial ? sourceMaterial.id : null,
+        after: sourceMaterial ? Number.parseFloat(sourceMaterial.quantite) : null
+      },
+      to: {
+        id: destinationMaterial ? destinationMaterial.id : null,
+        after: destinationMaterial ? Number.parseFloat(destinationMaterial.quantite) : null
+      }
+    };
+
+    // Point d'insertion pour historiser si besoin
+    // await Historique.create({...}, { transaction });
+
+    await transaction.commit();
+
+    return summary;
+  } catch (error) {
+    await transaction.rollback();
+    throw error;
+  }
+}
+
+module.exports = {
+  transferParNom
+};

--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -350,75 +350,106 @@
               <td><%= mc.quantitePrevue != null ? mc.quantitePrevue : '-' %></td>
               <td><%= mc.dateLivraisonPrevue ? mc.dateLivraisonPrevue.toISOString().split('T')[0] : '-' %></td>
               <td>
-
-                <% if (user && user.role === 'admin') { %>
-                <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#receptionModal<%= mc.id %>">
-                  Réceptionner
-                </button>
-
-                <div class="modal fade" id="receptionModal<%= mc.id %>" tabindex="-1" aria-labelledby="receptionModalLabel<%= mc.id %>" aria-hidden="true">
-                  <div class="modal-dialog">
-                    <div class="modal-content">
-                      <form action="/chantier/materielChantier/receptionner/<%= mc.id %>" method="POST">
-                        <div class="modal-header bg-success text-white">
-                          <h5 class="modal-title" id="receptionModalLabel<%= mc.id %>">Réceptionner du matériel</h5>
-                          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
-                        </div>
-                        <div class="modal-body">
-                          <p class="mb-2"><strong>Matériel :</strong> <%= mc.materiel ? mc.materiel.nom : 'N/A' %></p>
-                          <p class="mb-3"><strong>Chantier :</strong> <%= mc.chantier ? mc.chantier.nom : 'N/A' %></p>
-                          <div class="mb-3">
-                            <label for="quantiteReceptionnee<%= mc.id %>" class="form-label">Quantité réceptionnée</label>
-                            <input type="number" class="form-control" id="quantiteReceptionnee<%= mc.id %>" name="quantiteReceptionnee" min="1" required>
-                          </div>
-                        </div>
-                        <div class="modal-footer">
-                          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
-                          <button type="submit" class="btn btn-success">Confirmer</button>
-                        </div>
-                      </form>
-                    </div>
-                  </div>
+                <%
+                  const materielAssoc = mc.materiel;
+                  const assocChantierId = materielAssoc && materielAssoc.chantierId !== undefined && materielAssoc.chantierId !== null
+                    ? String(materielAssoc.chantierId)
+                    : null;
+                  const currentChantierIdStr = mc.chantierId !== undefined && mc.chantierId !== null
+                    ? String(mc.chantierId)
+                    : null;
+                  const isSameChantier = Boolean(materielAssoc) && assocChantierId === currentChantierIdStr;
+                  const fallbackMaterielId = mc.materielId !== undefined && mc.materielId !== null
+                    ? mc.materielId
+                    : (materielAssoc ? materielAssoc.id : '');
+                  const transferMaterielId = isSameChantier && materielAssoc
+                    ? materielAssoc.id
+                    : fallbackMaterielId;
+                  const transferMaterielName = materielAssoc ? materielAssoc.nom : '';
+                %>
+                <div class="d-flex flex-wrap gap-1">
+                  <button
+                    type="button"
+                    class="btn btn-outline-success btn-sm transfer-btn"
+                    data-action="entree"
+                    data-context-type="CHANTIER"
+                    data-context-chantier-id="<%= mc.chantierId %>"
+                    data-materiel-id="<%= transferMaterielId !== undefined && transferMaterielId !== null ? transferMaterielId : '' %>"
+                    data-materiel-name="<%= transferMaterielName %>"
+                  >
+                    Entrée
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-outline-danger btn-sm transfer-btn"
+                    data-action="sortie"
+                    data-context-type="CHANTIER"
+                    data-context-chantier-id="<%= mc.chantierId %>"
+                    data-materiel-id="<%= transferMaterielId !== undefined && transferMaterielId !== null ? transferMaterielId : '' %>"
+                    data-materiel-name="<%= transferMaterielName %>"
+                  >
+                    Sortie
+                  </button>
+                  <a href="/chantier/materielChantier/info/<%= mc.id %>" class="btn btn-info btn-sm">Info</a>
+                  <% if (user && user.role === 'admin') { %>
+                    <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#receptionModal<%= mc.id %>">
+                      Réceptionner
+                    </button>
+                    <a href="/chantier/materielChantier/modifier/<%= mc.id %>" class="btn btn-warning btn-sm">Modifier</a>
+                    <button type="button" class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal<%= mc.id %>">
+                      Supprimer
+                    </button>
+                    <a href="/chantier/materielChantier/dupliquer/<%= mc.id %>" class="btn btn-outline-primary btn-sm">Dupliquer</a>
+                  <% } %>
                 </div>
 
-                <!-- Bouton ici -->
-                 <a href="/chantier/materielChantier/modifier/<%= mc.id %>" class="btn btn-warning btn-sm">Modifier</a>
-                <!-- Tu peux aussi ajouter un bouton pour supprimer ici -->
-                 <!-- Bouton pour ouvrir la modale -->
-<button type="button" class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal<%= mc.id %>">
-  Supprimer
-</button>
+                <% if (user && user.role === 'admin') { %>
+                  <div class="modal fade" id="receptionModal<%= mc.id %>" tabindex="-1" aria-labelledby="receptionModalLabel<%= mc.id %>" aria-hidden="true">
+                    <div class="modal-dialog">
+                      <div class="modal-content">
+                        <form action="/chantier/materielChantier/receptionner/<%= mc.id %>" method="POST">
+                          <div class="modal-header bg-success text-white">
+                            <h5 class="modal-title" id="receptionModalLabel<%= mc.id %>">Réceptionner du matériel</h5>
+                            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+                          </div>
+                          <div class="modal-body">
+                            <p class="mb-2"><strong>Matériel :</strong> <%= mc.materiel ? mc.materiel.nom : 'N/A' %></p>
+                            <p class="mb-3"><strong>Chantier :</strong> <%= mc.chantier ? mc.chantier.nom : 'N/A' %></p>
+                            <div class="mb-3">
+                              <label for="quantiteReceptionnee<%= mc.id %>" class="form-label">Quantité réceptionnée</label>
+                              <input type="number" class="form-control" id="quantiteReceptionnee<%= mc.id %>" name="quantiteReceptionnee" min="1" required>
+                            </div>
+                          </div>
+                          <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                            <button type="submit" class="btn btn-success">Confirmer</button>
+                          </div>
+                        </form>
+                      </div>
+                    </div>
+                  </div>
 
-<!-- Modale Bootstrap -->
-<div class="modal fade" id="confirmDeleteModal<%= mc.id %>" tabindex="-1" aria-labelledby="confirmDeleteLabel<%= mc.id %>" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered">
-    <div class="modal-content">
-      <form action="/chantier/materielChantier/supprimer/<%= mc.id %>" method="POST">
-        <div class="modal-header bg-danger text-white">
-          <h5 class="modal-title" id="confirmDeleteLabel<%= mc.id %>">Confirmer la suppression</h5>
-          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
-        </div>
-        <div class="modal-body">
-          Êtes-vous sûr de vouloir supprimer ce matériel du chantier ?<br>
-          <strong>Cette action est irréversible.</strong>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
-          <button type="submit" class="btn btn-danger">Supprimer</button>
-        </div>
-      </form>
-    </div>
-  </div>
-</div>
-
-                          
-            <a href="/chantier/materielChantier/dupliquer/<%= mc.id %>" class="btn btn-outline-primary btn-sm">Dupliquer</a>
+                  <div class="modal fade" id="confirmDeleteModal<%= mc.id %>" tabindex="-1" aria-labelledby="confirmDeleteLabel<%= mc.id %>" aria-hidden="true">
+                    <div class="modal-dialog modal-dialog-centered">
+                      <div class="modal-content">
+                        <form action="/chantier/materielChantier/supprimer/<%= mc.id %>" method="POST">
+                          <div class="modal-header bg-danger text-white">
+                            <h5 class="modal-title" id="confirmDeleteLabel<%= mc.id %>">Confirmer la suppression</h5>
+                            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+                          </div>
+                          <div class="modal-body">
+                            Êtes-vous sûr de vouloir supprimer ce matériel du chantier ?<br>
+                            <strong>Cette action est irréversible.</strong>
+                          </div>
+                          <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                            <button type="submit" class="btn btn-danger">Supprimer</button>
+                          </div>
+                        </form>
+                      </div>
+                    </div>
+                  </div>
                 <% } %>
-
-            <a href="/chantier/materielChantier/info/<%= mc.id %>" class="btn btn-info btn-sm">Info</a>
-                
-
-
               </td>
             </tr>
           <% }); %>
@@ -430,11 +461,58 @@
       </tbody>
       
     </table>
-    
-   
+
+
 
   </div>
-  
+
+  <% const transferChantiers = Array.isArray(chantiers) ? chantiers : []; %>
+  <div class="modal fade" id="transferModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <form class="modal-content" id="transferForm" method="POST">
+        <div class="modal-header">
+          <h5 class="modal-title">
+            <span id="transferModalAction">Transfert</span> - <span id="transferModalMateriel"></span>
+          </h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
+        </div>
+        <div class="modal-body">
+          <input type="hidden" name="contextType" id="transferContextType" value="CHANTIER">
+          <input type="hidden" name="contextChantierId" id="transferContextChantierId" value="">
+          <input type="hidden" name="materielId" id="transferMaterielId" value="">
+          <input type="hidden" name="materielName" id="transferMaterielName" value="">
+
+          <div class="mb-3">
+            <label for="transferTargetChantierId" class="form-label">Chantier</label>
+            <select class="form-select" name="targetChantierId" id="transferTargetChantierId" required>
+              <option value="">-- Sélectionner un chantier --</option>
+              <% transferChantiers.forEach(function(c) { %>
+                <option value="<%= c.id %>"><%= c.nom %><% if (c.localisation) { %> - <%= c.localisation %><% } %></option>
+              <% }) %>
+            </select>
+          </div>
+
+          <div class="mb-3">
+            <label for="transferQuantite" class="form-label">Quantité</label>
+            <input
+              type="number"
+              class="form-control"
+              id="transferQuantite"
+              name="quantite"
+              min="0.01"
+              step="0.01"
+              required
+            >
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+          <button type="submit" class="btn btn-primary">Valider</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 
   <script nonce="<%= nonce %>">
@@ -443,6 +521,89 @@
     const navBar = document.querySelector('.navbar');
     const modifBtn = document.getElementById('toggleModif');
     const modifInput = document.getElementById('triModification');
+    const transferModalElement = document.getElementById('transferModal');
+    const transferForm = document.getElementById('transferForm');
+    const transferActionLabel = document.getElementById('transferModalAction');
+    const transferMaterielLabel = document.getElementById('transferModalMateriel');
+    const transferContextTypeInput = document.getElementById('transferContextType');
+    const transferContextChantierInput = document.getElementById('transferContextChantierId');
+    const transferMaterielIdInput = document.getElementById('transferMaterielId');
+    const transferMaterielNameInput = document.getElementById('transferMaterielName');
+    const transferTargetSelect = document.getElementById('transferTargetChantierId');
+    const transferQuantityInput = document.getElementById('transferQuantite');
+    let transferModalInstance = null;
+
+    if (transferModalElement && window.bootstrap && typeof window.bootstrap.Modal === 'function') {
+      transferModalInstance = new window.bootstrap.Modal(transferModalElement);
+    }
+
+    document.querySelectorAll('.transfer-btn').forEach(button => {
+      button.addEventListener('click', () => {
+        if (!transferForm) {
+          return;
+        }
+
+        transferForm.reset();
+        const action = button.dataset.action || 'entree';
+        transferForm.setAttribute('action', `/transferts/${action}`);
+        if (transferContextTypeInput) {
+          transferContextTypeInput.value = button.dataset.contextType || 'CHANTIER';
+        }
+        if (transferContextChantierInput) {
+          transferContextChantierInput.value = button.dataset.contextChantierId || '';
+        }
+        if (transferMaterielIdInput) {
+          transferMaterielIdInput.value = button.dataset.materielId || '';
+        }
+        if (transferMaterielNameInput) {
+          transferMaterielNameInput.value = button.dataset.materielName || '';
+        }
+        if (transferMaterielLabel) {
+          transferMaterielLabel.textContent = button.dataset.materielName || '';
+        }
+        if (transferTargetSelect) {
+          transferTargetSelect.value = '';
+        }
+        if (transferQuantityInput) {
+          transferQuantityInput.value = '';
+        }
+        transferForm.dataset.transferAction = action;
+        if (transferActionLabel) {
+          transferActionLabel.textContent = action === 'entree' ? 'Entrée' : 'Sortie';
+        }
+
+        if (transferModalInstance) {
+          transferModalInstance.show();
+        }
+      });
+    });
+
+    if (transferForm) {
+      transferForm.addEventListener('submit', (event) => {
+        const action = transferForm.dataset.transferAction || 'entree';
+        const actionLabel = action === 'entree' ? "l'entrée" : 'la sortie';
+        const qtyValue = transferQuantityInput ? transferQuantityInput.value.trim() : '';
+        const normalizedQty = qtyValue.replace(/,/g, '.');
+        const qtyNumber = Number.parseFloat(normalizedQty);
+        if (!Number.isFinite(qtyNumber) || qtyNumber <= 0) {
+          event.preventDefault();
+          return;
+        }
+
+        const materialName = transferMaterielNameInput ? transferMaterielNameInput.value : '';
+        const selectedOption = transferTargetSelect && transferTargetSelect.selectedIndex >= 0
+          ? transferTargetSelect.options[transferTargetSelect.selectedIndex]
+          : null;
+        const chantierLabel = selectedOption ? selectedOption.text.trim() : '';
+        const confirmationMessage = `Confirmer ${actionLabel} de ${qtyValue || qtyNumber} unités\n` +
+          `Matériel : ${materialName}\n` +
+          `Chantier sélectionné : ${chantierLabel}`;
+        if (!window.confirm(confirmationMessage)) {
+          event.preventDefault();
+        }
+      });
+    }
+
     if (toggleBtn) {
       toggleBtn.addEventListener('click', () => {
         body.classList.toggle('mode-sombre');

--- a/views/materiel/dashboard.ejs
+++ b/views/materiel/dashboard.ejs
@@ -382,6 +382,28 @@
                   </td>
                   <td>
                     <div class="d-flex flex-wrap gap-1">
+                      <button
+                        type="button"
+                        class="btn btn-outline-success btn-sm mb-1 transfer-btn"
+                        data-action="entree"
+                        data-context-type="DEPOT"
+                        data-context-chantier-id=""
+                        data-materiel-id="<%= m.id %>"
+                        data-materiel-name="<%= m.nom %>"
+                      >
+                        Entrée
+                      </button>
+                      <button
+                        type="button"
+                        class="btn btn-outline-danger btn-sm mb-1 transfer-btn"
+                        data-action="sortie"
+                        data-context-type="DEPOT"
+                        data-context-chantier-id=""
+                        data-materiel-id="<%= m.id %>"
+                        data-materiel-name="<%= m.nom %>"
+                      >
+                        Sortie
+                      </button>
                       <a href="/materiel/info/<%= m.id %>" class="btn btn-info btn-sm mb-1">Info</a>
                       <% if (user && user.role === 'admin') { %>
                         <a href="/materiel/editer/<%= m.id %>" class="btn btn-primary btn-sm mb-1">Modifier</a>
@@ -425,6 +447,28 @@
           </li>
         </ul>
         <div class="mt-3 d-flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="btn btn-sm btn-outline-success transfer-btn"
+            data-action="entree"
+            data-context-type="DEPOT"
+            data-context-chantier-id=""
+            data-materiel-id="<%= m.id %>"
+            data-materiel-name="<%= m.nom %>"
+          >
+            Entrée
+          </button>
+          <button
+            type="button"
+            class="btn btn-sm btn-outline-danger transfer-btn"
+            data-action="sortie"
+            data-context-type="DEPOT"
+            data-context-chantier-id=""
+            data-materiel-id="<%= m.id %>"
+            data-materiel-name="<%= m.nom %>"
+          >
+            Sortie
+          </button>
           <a href="/materiel/info/<%= m.id %>" class="btn btn-sm btn-info">Info</a>
           <% if (user && user.role==='admin') { %>
             <a href="/materiel/editer/<%=m.id%>" class="btn btn-sm btn-primary">Modifier</a>
@@ -441,7 +485,54 @@
 
       </div>
     </div>
-  </div> <!-- /container -->
+</div> <!-- /container -->
+
+  <% const transferChantiers = Array.isArray(chantiers) ? chantiers : []; %>
+  <div class="modal fade" id="transferModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <form class="modal-content" id="transferForm" method="POST">
+        <div class="modal-header">
+          <h5 class="modal-title">
+            <span id="transferModalAction">Transfert</span> - <span id="transferModalMateriel"></span>
+          </h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
+        </div>
+        <div class="modal-body">
+          <input type="hidden" name="contextType" id="transferContextType" value="DEPOT">
+          <input type="hidden" name="contextChantierId" id="transferContextChantierId" value="">
+          <input type="hidden" name="materielId" id="transferMaterielId" value="">
+          <input type="hidden" name="materielName" id="transferMaterielName" value="">
+
+          <div class="mb-3">
+            <label for="transferTargetChantierId" class="form-label">Chantier</label>
+            <select class="form-select" name="targetChantierId" id="transferTargetChantierId" required>
+              <option value="">-- Sélectionner un chantier --</option>
+              <% transferChantiers.forEach(function(c) { %>
+                <option value="<%= c.id %>"><%= c.nom %><% if (c.localisation) { %> - <%= c.localisation %><% } %></option>
+              <% }) %>
+            </select>
+          </div>
+
+          <div class="mb-3">
+            <label for="transferQuantite" class="form-label">Quantité</label>
+            <input
+              type="number"
+              class="form-control"
+              id="transferQuantite"
+              name="quantite"
+              min="0.01"
+              step="0.01"
+              required
+            >
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+          <button type="submit" class="btn btn-primary">Valider</button>
+        </div>
+      </form>
+    </div>
+  </div>
 
   <!-- Scripts Bootstrap -->
   <script src="/js/bootstrap.bundle.min.js"></script>
@@ -452,6 +543,91 @@
     const toggleBtn = document.getElementById('toggleMode');
     const body = document.body;
     const navBar = document.querySelector('.navbar');
+
+    const transferModalElement = document.getElementById('transferModal');
+    const transferForm = document.getElementById('transferForm');
+    const transferActionLabel = document.getElementById('transferModalAction');
+    const transferMaterielLabel = document.getElementById('transferModalMateriel');
+    const transferContextTypeInput = document.getElementById('transferContextType');
+    const transferContextChantierInput = document.getElementById('transferContextChantierId');
+    const transferMaterielIdInput = document.getElementById('transferMaterielId');
+    const transferMaterielNameInput = document.getElementById('transferMaterielName');
+    const transferTargetSelect = document.getElementById('transferTargetChantierId');
+    const transferQuantityInput = document.getElementById('transferQuantite');
+    let transferModalInstance = null;
+
+    if (transferModalElement && window.bootstrap && typeof window.bootstrap.Modal === 'function') {
+      transferModalInstance = new window.bootstrap.Modal(transferModalElement);
+    }
+
+    document.querySelectorAll('.transfer-btn').forEach(button => {
+      button.addEventListener('click', () => {
+        if (!transferForm) {
+          return;
+        }
+
+        transferForm.reset();
+        const action = button.dataset.action || 'entree';
+        transferForm.setAttribute('action', `/transferts/${action}`);
+        if (transferContextTypeInput) {
+          transferContextTypeInput.value = button.dataset.contextType || 'DEPOT';
+        }
+        if (transferContextChantierInput) {
+          transferContextChantierInput.value = button.dataset.contextChantierId || '';
+        }
+        if (transferMaterielIdInput) {
+          transferMaterielIdInput.value = button.dataset.materielId || '';
+        }
+        if (transferMaterielNameInput) {
+          transferMaterielNameInput.value = button.dataset.materielName || '';
+        }
+        if (transferMaterielLabel) {
+          transferMaterielLabel.textContent = button.dataset.materielName || '';
+        }
+        if (transferTargetSelect) {
+          transferTargetSelect.value = '';
+        }
+        if (transferQuantityInput) {
+          transferQuantityInput.value = '';
+        }
+        if (transferForm) {
+          transferForm.dataset.transferAction = action;
+        }
+        if (transferActionLabel) {
+          transferActionLabel.textContent = action === 'entree' ? 'Entrée' : 'Sortie';
+        }
+
+        if (transferModalInstance) {
+          transferModalInstance.show();
+        }
+      });
+    });
+
+    if (transferForm) {
+      transferForm.addEventListener('submit', (event) => {
+        const action = transferForm.dataset.transferAction || 'entree';
+        const actionLabel = action === 'entree' ? "l'entrée" : 'la sortie';
+        const qtyValue = transferQuantityInput ? transferQuantityInput.value.trim() : '';
+        const normalizedQty = qtyValue.replace(/,/g, '.');
+        const qtyNumber = Number.parseFloat(normalizedQty);
+        if (!Number.isFinite(qtyNumber) || qtyNumber <= 0) {
+          event.preventDefault();
+          return;
+        }
+
+        const materialName = transferMaterielNameInput ? transferMaterielNameInput.value : '';
+        const selectedOption = transferTargetSelect && transferTargetSelect.selectedIndex >= 0
+          ? transferTargetSelect.options[transferTargetSelect.selectedIndex]
+          : null;
+        const chantierLabel = selectedOption ? selectedOption.text.trim() : '';
+        const confirmationMessage = `Confirmer ${actionLabel} de ${qtyValue || qtyNumber} unités\n` +
+          `Matériel : ${materialName}\n` +
+          `Chantier sélectionné : ${chantierLabel}`;
+        if (!window.confirm(confirmationMessage)) {
+          event.preventDefault();
+        }
+      });
+    }
 
     toggleBtn.addEventListener('click', () => {
       body.classList.toggle('mode-sombre');


### PR DESCRIPTION
## Summary
- remove the duplicate /user route registration in app.js
- derive chantier transfer button metadata from the associated material, falling back to the stored materielId when needed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68de38071ca08328996c46e918ed47d1