### PR TITLE
Gérer le pivot MaterielChantier lors des transferts

### DIFF
--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -363,7 +363,14 @@
                   } else if (typeof mc !== 'undefined' && mc && Number(mc.chantierId) === Number(chantierCourantId)) {
                     sourceMat = mc;
                   }
-                  var sourceMatId  = sourceMat ? sourceMat.id : '';
+                  var sourceMatId = '';
+                  if (sourceMat) {
+                    if (typeof sourceMat.materielId !== 'undefined' && sourceMat.materielId !== null) {
+                      sourceMatId = sourceMat.materielId;
+                    } else {
+                      sourceMatId = sourceMat.id;
+                    }
+                  }
                   var sourceMatNom = (sourceMat && sourceMat.nom)
                                    || (typeof mc !== 'undefined' && mc && mc.materiel && mc.materiel.nom)
                                    || (typeof mc !== 'undefined' && mc && mc.nom)
@@ -489,7 +496,7 @@
         </div>
         <div class="modal-body">
           <input type="hidden" name="contextType" id="transferContextType" value="CHANTIER">
-          <input type="hidden" name="contextChantierId" id="transferContextChantierId" value="">
+          <input type="hidden" name="contextChantierId" id="transferContextChantierId" value="<%= chantierCourant ? chantierCourant.id : '' %>">
           <input type="hidden" name="materielId" id="transferMaterielId" value="">
           <input type="hidden" name="materielName" id="transferMaterielName" value="">
 


### PR DESCRIPTION
## Summary
- utiliser les lignes MaterielChantier comme source et destination lors des transferts chantier
- sécuriser la création des pivots manquants pendant les entrées et sorties
- transmettre l’identifiant Materiel et le chantier courant depuis la vue chantier

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68de6daa1b34832891e5eeb696d0df03