### PR TITLE
Adjust stock chantier header spacing on desktop

### DIFF
--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -27,6 +27,7 @@
       color: var(--text-primary);
       font-family: 'Inter', 'Segoe UI', sans-serif;
       backdrop-filter: blur(8px);
+      margin: 0;
     }
 
     .navbar {


### PR DESCRIPTION
## Summary
- remove the default body margin on the Stock Chantier page so the fixed header aligns flush with the top of desktop viewports

## Testing
- npm start *(fails: missing module 'cloudinary')*

------
https://chatgpt.com/codex/tasks/task_b_68de74adef6c832894c1ed116f192640