### PR TITLE
Improve mobile table readability

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -44,3 +44,39 @@ body.mode-sombre thead th {
   }
   
   /* Ajoute d'autres styles personnalisés ici si nécessaire */
+
+/* === Mobile readability tweaks (≤ 768px) === */
+@media (max-width: 768px) {
+  /* par défaut, couper pour éviter les chevauchements */
+  .table-stock th,
+  .table-stock td {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  /* Désignation : montrer le nom en entier, avec retour à la ligne si besoin */
+  .table-stock .col-designation {
+    white-space: normal !important;
+    overflow: visible !important;
+    text-overflow: clip !important;
+    word-break: break-word;
+    hyphens: auto;
+  }
+
+  /* Emplacement et Rack : autoriser retour à la ligne pour éviter chevauchements */
+  .table-stock .col-emplacement,
+  .table-stock .col-rack {
+    white-space: normal;
+    word-break: break-word;
+    hyphens: auto;
+  }
+
+  /* élargir un peu la table pour plus de lisibilité */
+  .table-stock {
+    min-width: 1350px;
+  }
+}
+
+/* Compact+ : ajuster min-width pour éviter chevauchements */
+body.compact-mobile .table-stock .col-emplacement { min-width: 120px; }
+body.compact-mobile .table-stock .col-rack { min-width: 80px; }


### PR DESCRIPTION
## Summary
- allow stock table designation, emplacement, and rack columns to wrap on small screens
- widen the stock table on mobile to avoid overlap and maintain readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68de868d4c1c8328afc0d9b793e854b5