### PR TITLE
Ajuster l'affichage des actions en mode Compact+

### DIFF
--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -220,6 +220,8 @@
     .stock-table-wrap {
       overflow-x: auto;
       -webkit-overflow-scrolling: touch;
+      /* Espace pour la colonne sticky des actions quand Compact+ est actif */
+      padding-right: 0;
     }
 
     .table-stock {
@@ -307,7 +309,7 @@
         min-width: 140px !important;
       }
       .table-stock {
-        min-width: 1350px;
+        min-width: 1450px;
       }
     }
 
@@ -356,6 +358,28 @@
     }
     body.compact-mobile .table-stock .col-rack {
       min-width: 90px;
+    }
+
+    /* --- Compact+: garder les libellés de boutons complets --- */
+    body.compact-mobile .table-stock .col-actions {
+      min-width: 260px;
+      position: sticky;
+      right: 0;
+      background: rgba(22, 18, 37, .92);
+      backdrop-filter: blur(2px);
+      z-index: 3;
+    }
+    body.compact-mobile .stock-table-wrap {
+      padding-right: 260px;
+    }
+    body.compact-mobile .table-stock td.actions .btn-wrap {
+      flex-wrap: nowrap;
+      gap: 6px;
+    }
+    body.compact-mobile .table-stock td.actions .btn {
+      font-size: 12px;
+      padding: 6px 10px;
+      white-space: nowrap;
     }
 
     body.compact-mobile .table-stock th:nth-child(5),

--- a/views/materiel/dashboard.ejs
+++ b/views/materiel/dashboard.ejs
@@ -36,6 +36,7 @@
     .stock-table-wrap {
       overflow-x: auto;
       -webkit-overflow-scrolling: touch;
+      padding-right: 0;
     }
 
     .table-stock {
@@ -98,7 +99,7 @@
         min-width: 140px !important;
       }
       .table-stock {
-        min-width: 1250px;
+        min-width: 1400px;
       }
     }
 
@@ -148,6 +149,27 @@
       min-width: 120px;
     }
 
+    /* --- Compact+: garder les libellés de boutons complets --- */
+    body.compact-mobile .table-stock .col-actions {
+      min-width: 260px;
+      position: sticky;
+      right: 0;
+      background: rgba(22, 18, 37, .92);
+      backdrop-filter: blur(2px);
+      z-index: 3;
+    }
+    body.compact-mobile .stock-table-wrap {
+      padding-right: 260px;
+    }
+    body.compact-mobile .table-stock td.actions .btn-wrap {
+      flex-wrap: nowrap;
+      gap: 6px;
+    }
+    body.compact-mobile .table-stock td.actions .btn {
+      font-size: 12px;
+      padding: 6px 10px;
+      white-space: nowrap;
+    }
     body.compact-mobile .table-stock th:nth-child(5),
     body.compact-mobile .table-stock td:nth-child(5) {
       min-width: 70px;


### PR DESCRIPTION
## Summary
- augmente la largeur minimale des tableaux pour préserver l'affichage complet des boutons en affichage Compact+
- rend la colonne d'actions sticky et ajoute un padding droit dédié pour empêcher son chevauchement
- ajuste le style des boutons d'action en Compact+ pour éviter les retours à la ligne

## Testing
- non effectué (non demandé)


------
https://chatgpt.com/codex/tasks/task_b_68de8f5b40c88328853805086027b50b