### PR TITLE
Fix stock popups clipping and improve input contrast

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -54,6 +54,10 @@ body.mode-sombre thead th {
     text-overflow: ellipsis;
   }
 
+  .table-stock .col-actions {
+    overflow: visible !important;
+  }
+
   /* Désignation : montrer le nom en entier, avec retour à la ligne si besoin */
   .table-stock .col-designation {
     white-space: normal !important;
@@ -80,3 +84,6 @@ body.mode-sombre thead th {
 /* Compact+ : ajuster min-width pour éviter chevauchements */
 body.compact-mobile .table-stock .col-emplacement { min-width: 120px; }
 body.compact-mobile .table-stock .col-rack { min-width: 80px; }
+body.compact-mobile .table-stock .col-actions {
+  overflow: visible !important;
+}

--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -269,6 +269,14 @@
       white-space: nowrap;
     }
 
+    .table-stock th.col-actions,
+    .table-stock td.col-actions {
+      position: relative;
+      overflow: visible;
+      white-space: normal;
+      z-index: 1;
+    }
+
     .table-stock td .btn-group,
     .table-stock td .btn-wrap {
       display: flex;
@@ -305,6 +313,10 @@
         word-break: break-word;
         hyphens: auto;
         min-width: 140px !important;
+      }
+      .table-stock .col-actions {
+        overflow: visible !important;
+        white-space: normal !important;
       }
       .table-stock {
         min-width: 1350px;
@@ -350,6 +362,10 @@
       text-overflow: clip !important;
       word-break: break-word;
       hyphens: auto;
+    }
+    body.compact-mobile .table-stock .col-actions {
+      overflow: visible !important;
+      white-space: normal !important;
     }
     body.compact-mobile .table-stock .col-emplacement {
       min-width: 130px;
@@ -467,6 +483,23 @@
 
     .modal-footer {
       border-top-color: rgba(169, 120, 255, 0.25);
+    }
+
+    .modal-content .form-control {
+      background: rgba(12, 8, 32, 0.92);
+      border: 1px solid rgba(169, 120, 255, 0.35);
+      color: var(--text-primary);
+    }
+
+    .modal-content .form-control:focus {
+      border-color: rgba(199, 172, 255, 0.7);
+      box-shadow: 0 0 0 0.25rem rgba(123, 106, 255, 0.25);
+      background: rgba(18, 12, 48, 0.96);
+      color: #ffffff;
+    }
+
+    .modal-content .form-control::placeholder {
+      color: rgba(247, 244, 255, 0.65);
     }
 
     .transfer-btn {

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -225,6 +225,29 @@
       background: rgba(15, 22, 58, 0.95);
     }
 
+    .form-control::placeholder {
+      color: rgba(245, 247, 255, 0.65);
+    }
+
+    .form-control[type="password"],
+    input[type="password"].form-control,
+    input[type="password"] {
+      color: #f5f7ff !important;
+    }
+
+    .form-control[type="password"]::placeholder,
+    input[type="password"].form-control::placeholder {
+      color: rgba(245, 247, 255, 0.65);
+    }
+
+    .form-control:-webkit-autofill,
+    .form-control:-webkit-autofill:hover,
+    .form-control:-webkit-autofill:focus {
+      -webkit-text-fill-color: #f5f7ff;
+      transition: background-color 9999s ease-in-out 0s;
+      box-shadow: 0 0 0px 1000px rgba(10, 13, 36, 0.9) inset;
+    }
+
     .btn-primary {
       background: linear-gradient(135deg, #3a4bff, #9f3aff);
       border: none;

--- a/views/materiel/dashboard.ejs
+++ b/views/materiel/dashboard.ejs
@@ -55,6 +55,14 @@
       white-space: nowrap;
     }
 
+    .table-stock th.col-actions,
+    .table-stock td.col-actions {
+      position: relative;
+      overflow: visible;
+      white-space: normal;
+      z-index: 1;
+    }
+
     .table-stock td .btn-group,
     .table-stock td .btn-wrap {
       display: flex;
@@ -96,6 +104,10 @@
         word-break: break-word;
         hyphens: auto;
         min-width: 140px !important;
+      }
+      .table-stock .col-actions {
+        overflow: visible !important;
+        white-space: normal !important;
       }
       .table-stock {
         min-width: 1250px;
@@ -176,6 +188,29 @@
     body.compact-mobile .table-stock td .btn {
       padding: 4px 6px;
       font-size: 12px;
+    }
+
+    body.compact-mobile .table-stock th.col-actions,
+    body.compact-mobile .table-stock td.col-actions {
+      overflow: visible !important;
+      white-space: normal !important;
+    }
+
+    .modal-content .form-control {
+      background: rgba(12, 8, 32, 0.92);
+      border: 1px solid rgba(153, 134, 255, 0.35);
+      color: #f7f4ff;
+    }
+
+    .modal-content .form-control:focus {
+      border-color: rgba(187, 170, 255, 0.65);
+      box-shadow: 0 0 0 0.25rem rgba(123, 106, 255, 0.25);
+      background: rgba(18, 12, 48, 0.96);
+      color: #ffffff;
+    }
+
+    .modal-content .form-control::placeholder {
+      color: rgba(247, 244, 255, 0.65);
     }
 
     /* =================== MODE SOMBRE =================== */


### PR DESCRIPTION
## Summary
- allow stock action buttons to display their popups fully by preventing action cells from clipping their content
- align modal form styling so quantity inputs in reception dialogs stay readable on the dark background
- ensure the login password field uses a white font and placeholder for better contrast

## Testing
- Not run (sqlite3 dependency not available in container)

------
https://chatgpt.com/codex/tasks/task_b_68df8fe890348328bd14b8911a352820