### PR TITLE
Fix modal stacking context issues

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -33,6 +33,21 @@ body.mode-sombre .table-materiel td {
 }
 
 
+/* Met les modales au-dessus de tout */
+.modal-backdrop {
+  z-index: 5000 !important;
+}
+
+.modal {
+  z-index: 5005 !important;
+}
+
+/* Optionnel : centrer verticalement toutes les modales par défaut */
+.modal .modal-dialog {
+  margin-top: 0;
+}
+
+
 body.mode-sombre thead th {
     background-color: #2c2c2c !important;
     color: #ffffff;

--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -999,7 +999,7 @@
   </div>
 
   <div class="modal fade" id="globalReceptionModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog">
+    <div class="modal-dialog modal-dialog-centered">
       <div class="modal-content">
         <form id="globalReceptionForm" action="" method="POST">
           <div class="modal-header bg-success text-white">
@@ -1028,7 +1028,7 @@
   </div>
 
   <div class="modal fade" id="globalDeleteModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog">
+    <div class="modal-dialog modal-dialog-centered">
       <div class="modal-content">
         <form id="globalDeleteForm" action="" method="POST">
           <div class="modal-header bg-danger text-white">
@@ -1094,6 +1094,23 @@
       </form>
     </div>
   </div>
+
+  <script nonce="<%= nonce %>">
+    (function () {
+      var ids = [
+        'globalPhotoModal',
+        'globalReceptionModal',
+        'globalDeleteModal',
+        'transferModal'
+      ];
+      ids.forEach(function (id) {
+        var el = document.getElementById(id);
+        if (el && el.parentNode !== document.body) {
+          document.body.appendChild(el);
+        }
+      });
+    })();
+  </script>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 


### PR DESCRIPTION
## Summary
- ensure global modals are moved under the body at runtime to avoid stacking context conflicts
- raise modal backdrop and dialog z-index values so overlays stay above the interface
- vertically center the reception and delete modals for consistency with the photo modal

## Testing
- npm start *(fails: Cannot find module 'cloudinary')*


------
https://chatgpt.com/codex/tasks/task_b_68df989dc8bc8328ad684e823259c1d1