### PR TITLE
Add support for filtering materials by empty category

### DIFF
--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -170,7 +170,12 @@ async function fetchMaterielChantiersWithFilters(query, { includePhotos = true, 
   const whereChantier = chantierIdInt ? { chantierId: chantierIdInt } : {};
   const whereMateriel = {};
 
-  if (categorie) {
+  if (categorie === '__vide__') {
+    whereMateriel[Op.or] = [
+      { categorie: { [Op.is]: null } },
+      { categorie: '' }
+    ];
+  } else if (categorie) {
     whereMateriel.categorie = { [Op.iLike]: `%${categorie}%` };
   }
   if (fournisseur) {
@@ -771,7 +776,41 @@ router.get('/', ensureAuthenticated, async (req, res) => {
     const marques = Array.from(
       new Set(marquesRaw.map(item => item.marque).filter(Boolean))
     ).sort((a, b) => a.localeCompare(b, 'fr', { sensitivity: 'base' }));
-    const categories = await loadCategories();
+
+    // Charger uniquement les catégories des matériels du chantier actif (ou tous si aucun chantier sélectionné)
+    const activeChantierId = activeFilters.chantierId ? parseInt(activeFilters.chantierId, 10) : null;
+    const mcWhereForCats = activeChantierId ? { chantierId: activeChantierId } : {};
+    const catsRaw = await Materiel.findAll({
+      attributes: [[sequelize.fn('DISTINCT', sequelize.col('Materiel.categorie')), 'categorie']],
+      include: [{
+        model: MaterielChantier,
+        as: 'materielChantiers',
+        where: mcWhereForCats,
+        attributes: [],
+        required: true
+      }],
+      where: {
+        categorie: { [Op.and]: [{ [Op.not]: null }, { [Op.ne]: '' }] }
+      },
+      raw: true
+    });
+    const categories = catsRaw
+      .map(c => c.categorie)
+      .filter(Boolean)
+      .sort((a, b) => a.localeCompare(b, 'fr', { sensitivity: 'base' }));
+
+    // Vérifier s'il existe des matériels sans catégorie dans le chantier actif
+    const emptyCategCount = await MaterielChantier.count({
+      where: mcWhereForCats,
+      include: [{
+        model: Materiel,
+        as: 'materiel',
+        where: { [Op.or]: [{ categorie: { [Op.is]: null } }, { categorie: '' }] },
+        required: true,
+        attributes: []
+      }]
+    });
+    const hasEmptyCategorie = emptyCategCount > 0;
 
     const paginationQuery = CHANTIER_FILTER_KEYS.reduce((acc, key) => {
       if (key === 'page') return acc;
@@ -789,6 +828,7 @@ router.get('/', ensureAuthenticated, async (req, res) => {
       fournisseurs,
       marques,
       categories,
+      hasEmptyCategorie,
       lowStockItemsAll,
       upcomingDeliveries,
       user: req.user,

--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -1604,6 +1604,9 @@
   <label for="categorieSelect" class="form-label">Catégorie</label>
   <select class="form-select" name="categorie" id="categorieSelect">
     <option value="">-- Toutes les catégories --</option>
+    <% if (hasEmptyCategorie) { %>
+      <option value="__vide__" <%= categorie === '__vide__' ? 'selected' : '' %>>-- Sans catégorie --</option>
+    <% } %>
     <% (categories || []).forEach(function(cat){ %>
       <option value="<%= cat %>" <%= categorie === cat ? 'selected' : '' %>><%= cat %></option>
     <% }); %>


### PR DESCRIPTION
## Summary
This PR adds the ability to filter materials by empty or missing categories in the chantier (worksite) view. Previously, materials without a category could not be filtered separately.

## Key Changes
- **Filter Logic**: Modified `fetchMaterielChantiersWithFilters()` to handle a special `__vide__` category value that filters for materials with null or empty string categories
- **Category Loading**: Updated the category list loading to:
  - Only fetch categories from materials in the active chantier (or all materials if no chantier is selected)
  - Exclude null and empty categories from the main category list
  - Check if any materials without categories exist in the active chantier
- **UI Enhancement**: Added a "-- Sans catégorie --" (Without category) option to the category filter dropdown that only appears when materials without categories exist in the current chantier
- **Data Passing**: Added `hasEmptyCategorie` flag to the view context to conditionally render the empty category option

## Implementation Details
- Uses Sequelize's `Op.or` operator to match both `null` and empty string values when filtering by empty category
- Implements efficient counting via `MaterielChantier.count()` to determine if the empty category option should be displayed
- Maintains French locale-aware sorting for category names
- The empty category filter respects the active chantier selection, showing only relevant empty categories

https://claude.ai/code/session_019KKQbYP8JAYq1RhcM5j6WN