### PR TITLE
Fix table overflow and sticky header positioning in stock view

### DIFF
--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -453,7 +453,8 @@
       border-radius: 20px;
       border: 1px solid rgba(169, 120, 255, 0.18);
       box-shadow: 0 22px 50px rgba(5, 0, 16, 0.65);
-      overflow: hidden;
+      /* clip plutôt que hidden : conserve les coins arrondis sans créer de conteneur scroll */
+      overflow: clip;
     }
 
     /* Étendre la zone tableau sur mobile/tablette pour profiter de toute la largeur utile */
@@ -484,24 +485,11 @@
       color: var(--text-primary, #f7f4ff);
     }
 
-    /* --- STOCK TABLE: force one-row, enable horizontal scroll --- */
+    /* --- STOCK TABLE: scroll horizontal uniquement, la page défile verticalement --- */
     .stock-table-wrap {
       overflow-x: auto;
-      overflow-y: auto;
       -webkit-overflow-scrolling: touch;
-      /* le tableau devient sa propre zone scrollable (verticale) */
-      max-height: calc(100vh - var(--navbar-h) - 260px);
-      /* évite l'effet "scroll page + scroll tableau" trop agressif sur certains navigateurs */
-      overscroll-behavior: contain;
-      /* nécessaire pour un sticky propre dans certains cas */
       position: relative;
-    }
-
-    /* Sur petits écrans, on laisse plus de place aux filtres au-dessus */
-    @media (max-width: 992px) {
-      .stock-table-wrap {
-        max-height: calc(100vh - var(--navbar-h) - 320px);
-      }
     }
 
     .table-stock {
@@ -823,7 +811,7 @@
 
     .table-materiel thead th {
       position: sticky;
-      top: 0;
+      top: var(--navbar-h);
       z-index: 1100;
       background: linear-gradient(135deg, rgba(79, 50, 255, 0.95), rgba(123, 62, 243, 0.85));
       border-bottom: none;


### PR DESCRIPTION
## Summary
This PR refines the CSS styling for the stock table layout to improve scrolling behavior and header positioning, particularly addressing issues with overflow handling and sticky header alignment.

## Key Changes
- **Overflow handling**: Changed `.stock-table-container` from `overflow: hidden` to `overflow: clip` to preserve rounded corners without creating an unintended scroll container
- **Table scroll simplification**: Removed vertical scroll capability from `.stock-table-wrap` (removed `overflow-y: auto`, `max-height`, and `overscroll-behavior` properties) to ensure only horizontal scrolling occurs while the page handles vertical scrolling
- **Sticky header positioning**: Updated `.table-materiel thead th` sticky positioning from `top: 0` to `top: var(--navbar-h)` to account for the navbar height and prevent header overlap
- **Responsive adjustments**: Removed the media query that adjusted `max-height` for smaller screens, as the max-height constraint is no longer needed
- **Code comments**: Updated French comments to clarify the intended scrolling behavior

## Implementation Details
These changes address the "scroll page + scroll tableau" conflict by ensuring the table wrapper only handles horizontal scrolling while the page itself manages vertical scrolling. The sticky header now properly positions itself below the navbar using the CSS variable, improving the user experience on all screen sizes.

https://claude.ai/code/session_01C4EjEUgnwWT7HNQpNcfTau