### PR TITLE
Simplify duplicate filter to use material name only

### DIFF
--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -188,26 +188,22 @@ async function fetchMaterielChantiersWithFilters(query, { includePhotos = true, 
   const order = [];
   const shouldFilterDuplicates = doublons === '1';
   const andConditions = [];
-  let normalizedCategoryExpr = null;
   let normalizedNameExpr = null;
   if (shouldFilterDuplicates && chantierIdInt) {
-    normalizedCategoryExpr = `regexp_replace(upper(unaccent(trim("materiel"."categorie"))), '[^A-Z0-9]+', '', 'g')`;
     normalizedNameExpr = `regexp_replace(upper(unaccent(trim("materiel"."nom"))), '[^A-Z0-9]+', '', 'g')`;
     const chantierIdSql = sequelize.escape(chantierIdInt);
     const duplicateFilterSql = `
-      (${normalizedCategoryExpr}, ${normalizedNameExpr}) IN (
+      ${normalizedNameExpr} IN (
         SELECT
-          regexp_replace(upper(unaccent(trim(m.categorie))), '[^A-Z0-9]+', '', 'g') AS cat_norm,
           regexp_replace(upper(unaccent(trim(m.nom))), '[^A-Z0-9]+', '', 'g') AS nom_norm
         FROM materiel_chantiers mc
         JOIN materiels m ON m.id = mc."materielId"
         WHERE mc."chantierId" = ${chantierIdSql}
-        GROUP BY cat_norm, nom_norm
+        GROUP BY nom_norm
         HAVING COUNT(*) > 1
       )
     `;
     andConditions.push(sequelize.literal(duplicateFilterSql));
-    order.push([sequelize.literal(normalizedCategoryExpr), 'ASC']);
     order.push([sequelize.literal(normalizedNameExpr), 'ASC']);
     order.push([{ model: Materiel, as: 'materiel' }, 'nom', 'ASC']);
   }


### PR DESCRIPTION
## Summary
Simplified the duplicate material filtering logic in the chantier routes to filter based on material name alone, removing the category from the duplicate detection criteria.

## Key Changes
- Removed `normalizedCategoryExpr` variable that was normalizing the material category field
- Updated the duplicate filter SQL query to check only normalized material names instead of tuples of (category, name)
- Simplified the GROUP BY clause from `(cat_norm, nom_norm)` to just `nom_norm`
- Removed category-based ordering from the results

## Implementation Details
The duplicate detection now identifies materials as duplicates based solely on their normalized name (uppercase, unaccented, alphanumeric characters only), rather than requiring both the category and name to match. This makes the duplicate filtering less strict and focuses on name-based deduplication.

https://claude.ai/code/session_01HJSz6oh951vwVCWTVvrnj3