### PR TITLE
Add Excel-style column resizing to stock table

### DIFF
--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -499,6 +499,65 @@
       min-width: 1400px;
     }
 
+    /* ── Redimensionnement des colonnes (style Excel) ─────────────── */
+    .table-stock thead th {
+      position: relative;
+    }
+
+    .col-resize-handle {
+      position: absolute;
+      right: -3px;
+      top: 0;
+      bottom: 0;
+      width: 8px;
+      cursor: col-resize;
+      background: transparent;
+      z-index: 20;
+      user-select: none;
+      -webkit-user-select: none;
+    }
+
+    .col-resize-handle::after {
+      content: '';
+      position: absolute;
+      right: 3px;
+      top: 20%;
+      bottom: 20%;
+      width: 2px;
+      border-radius: 2px;
+      background: transparent;
+      transition: background 0.15s;
+    }
+
+    .col-resize-handle:hover::after {
+      background: rgba(169, 120, 255, 0.65);
+    }
+
+    .col-resize-handle.resizing::after {
+      background: rgba(169, 120, 255, 1);
+      top: 0;
+      bottom: 0;
+    }
+
+    body.col-resize-dragging,
+    body.col-resize-dragging * {
+      cursor: col-resize !important;
+      user-select: none !important;
+      -webkit-user-select: none !important;
+    }
+
+    /* Quand les largeurs sont fixées par l'utilisateur */
+    .table-stock.col-widths-fixed {
+      table-layout: fixed !important;
+    }
+
+    .table-stock.col-widths-fixed thead th:not(.col-actions),
+    .table-stock.col-widths-fixed tbody td:not(.col-actions) {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    /* ───────────────────────────────────────────────────────────────── */
+
     .table-stock th,
     .table-stock td {
       vertical-align: middle;
@@ -1760,6 +1819,12 @@
         <label class="form-check-label" for="toggle-col-bdl">Bon de Livraison</label>
       </div>
     </div>
+    <div class="mt-3 pt-2 border-top border-secondary d-flex align-items-center gap-2" style="border-color: rgba(169,120,255,0.2) !important;">
+      <span class="text-muted small">Largeur des colonnes :</span>
+      <button type="button" class="btn btn-outline-secondary btn-sm btn-reset-col-widths" title="Remettre les largeurs de colonnes par défaut">
+        ↺ Réinitialiser les largeurs
+      </button>
+    </div>
   </div>
 
 
@@ -2491,6 +2556,143 @@
         cell.classList.remove('hidden-column');
       });
     })();
+  </script>
+
+  <script nonce="<%= nonce %>">
+    /* ── Redimensionnement des colonnes – style Excel ──────────────── */
+    (function () {
+      const COL_WIDTH_KEY = 'gs_chantier_col_widths_v1';
+      const table = document.querySelector('.table-stock');
+      if (!table) return;
+
+      /* Accès localStorage (même pattern que la section visibilité) */
+      const storage = (() => {
+        try {
+          if (typeof window === 'undefined' || !window.localStorage) return null;
+          const k = '__gs_cw_test__';
+          window.localStorage.setItem(k, '1');
+          window.localStorage.removeItem(k);
+          return window.localStorage;
+        } catch (_) { return null; }
+      })();
+
+      const saveWidths = (widths) => {
+        if (!storage) return;
+        try { storage.setItem(COL_WIDTH_KEY, JSON.stringify(widths)); } catch (_) {}
+      };
+
+      const loadWidths = () => {
+        if (!storage) return null;
+        try {
+          const raw = storage.getItem(COL_WIDTH_KEY);
+          return raw ? JSON.parse(raw) : null;
+        } catch (_) { return null; }
+      };
+
+      /* Clé identifiant une colonne (classe col-xxx) */
+      const getColKey = (th) =>
+        Array.from(th.classList).find(c => c.startsWith('col-')) || null;
+
+      /* Capture les largeurs actuelles de tous les th visibles */
+      const captureAllWidths = () => {
+        const result = {};
+        table.querySelectorAll('thead th').forEach(th => {
+          const key = getColKey(th);
+          if (key && !th.classList.contains('hidden-column') && !th.classList.contains('d-none')) {
+            result[key] = th.offsetWidth;
+          }
+        });
+        return result;
+      };
+
+      /* Applique un dictionnaire de largeurs aux th et passe en layout fixe */
+      const applyWidths = (widths) => {
+        if (!widths || Object.keys(widths).length === 0) return;
+        table.querySelectorAll('thead th').forEach(th => {
+          const key = getColKey(th);
+          if (key && widths[key] != null) {
+            th.style.width = widths[key] + 'px';
+          }
+        });
+        table.classList.add('col-widths-fixed');
+      };
+
+      /* Remet tout par défaut */
+      const resetWidths = () => {
+        table.querySelectorAll('thead th').forEach(th => {
+          th.style.width = '';
+        });
+        table.classList.remove('col-widths-fixed');
+        if (storage) {
+          try { storage.removeItem(COL_WIDTH_KEY); } catch (_) {}
+        }
+      };
+
+      /* ── Restauration au chargement ───────────────────────────────── */
+      const saved = loadWidths();
+      if (saved) applyWidths(saved);
+
+      /* ── Ajout des poignées sur chaque th ─────────────────────────── */
+      table.querySelectorAll('thead th').forEach(th => {
+        const key = getColKey(th);
+        /* On ignore les colonnes utilitaires sans classe col-xxx */
+        if (!key || th.classList.contains('d-none')) return;
+
+        const handle = document.createElement('div');
+        handle.className = 'col-resize-handle';
+        handle.setAttribute('title', 'Glisser pour redimensionner');
+        th.appendChild(handle);
+
+        handle.addEventListener('mousedown', (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+
+          /* Premier glisser : on fige toutes les largeurs d'abord */
+          if (!table.classList.contains('col-widths-fixed')) {
+            const current = captureAllWidths();
+            applyWidths(current);
+            saveWidths(current);
+          }
+
+          const startX    = e.clientX;
+          const startWidth = th.offsetWidth;
+
+          handle.classList.add('resizing');
+          document.body.classList.add('col-resize-dragging');
+
+          const onMouseMove = (ev) => {
+            const newWidth = Math.max(40, startWidth + (ev.clientX - startX));
+            th.style.width = newWidth + 'px';
+          };
+
+          const onMouseUp = (ev) => {
+            const newWidth = Math.max(40, startWidth + (ev.clientX - startX));
+            th.style.width = newWidth + 'px';
+
+            handle.classList.remove('resizing');
+            document.body.classList.remove('col-resize-dragging');
+
+            /* Sauvegarde */
+            const allWidths = loadWidths() || {};
+            allWidths[key] = newWidth;
+            saveWidths(allWidths);
+
+            document.removeEventListener('mousemove', onMouseMove);
+            document.removeEventListener('mouseup',   onMouseUp);
+          };
+
+          document.addEventListener('mousemove', onMouseMove);
+          document.addEventListener('mouseup',   onMouseUp);
+        });
+      });
+
+      /* ── Bouton "Réinitialiser les largeurs" ──────────────────────── */
+      const resetBtn = document.querySelector('.btn-reset-col-widths');
+      if (resetBtn) {
+        resetBtn.addEventListener('click', resetWidths);
+      }
+    })();
+    /* ─────────────────────────────────────────────────────────────── */
   </script>
 
   <div class="modal fade" id="shortcutsHelpModal" tabindex="-1" aria-labelledby="shortcutsHelpModalTitle" aria-hidden="true">


### PR DESCRIPTION
## Summary
This PR adds Excel-style column resizing functionality to the stock table, allowing users to dynamically adjust column widths by dragging resize handles. Column width preferences are persisted to localStorage.

## Key Changes
- **CSS Styling**: Added styles for column resize handles with hover and active states, including a purple accent color (`rgba(169, 120, 255)`)
- **Resize Handles**: Added draggable handles to each table header column that appear on hover
- **Drag Interaction**: Implemented mousedown/mousemove/mouseup event handlers to enable smooth column width adjustment with a minimum width of 40px
- **Layout Mode**: Table switches to `table-layout: fixed` when custom widths are applied to enable proper column resizing behavior
- **Persistence**: Column widths are saved to localStorage (`gs_chantier_col_widths_v1`) and automatically restored on page load
- **Reset Button**: Added "Réinitialiser les largeurs" button in the column visibility panel to restore default column widths and clear saved preferences
- **UX Polish**: Added visual feedback during resizing (cursor changes, handle highlighting, text selection prevention)

## Implementation Details
- Resize handles are positioned absolutely on the right edge of each header cell
- Column identification uses CSS class names (e.g., `col-xxx`) to track width preferences
- localStorage access is wrapped in a try-catch pattern consistent with existing code
- Handles are only added to visible columns (excluding hidden/d-none columns)
- First resize action automatically captures and fixes all current column widths before allowing adjustments
- Minimum column width of 40px prevents columns from becoming too narrow

https://claude.ai/code/session_01LddjrJz4mxy3Ti8D5Wvf6F