### PR TITLE
Fix stock table scrolling and sticky header positioning

### DIFF
--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -485,9 +485,11 @@
       color: var(--text-primary, #f7f4ff);
     }
 
-    /* --- STOCK TABLE: scroll horizontal uniquement, la page défile verticalement --- */
+    /* --- STOCK TABLE: scroll horizontal + vertical dans le conteneur, en-tête fixe --- */
     .stock-table-wrap {
       overflow-x: auto;
+      overflow-y: auto;
+      max-height: calc(100vh - var(--navbar-h) - 1rem);
       -webkit-overflow-scrolling: touch;
       position: relative;
     }
@@ -870,7 +872,7 @@
 
     .table-materiel thead th {
       position: sticky;
-      top: var(--navbar-h);
+      top: 0;
       z-index: 1100;
       background: linear-gradient(135deg, rgba(79, 50, 255, 0.95), rgba(123, 62, 243, 0.85));
       border-bottom: none;


### PR DESCRIPTION
## Summary
Improved the stock table layout by enabling vertical scrolling within the table container and fixing the sticky header positioning to work correctly with the scrollable container.

## Key Changes
- Added `overflow-y: auto` to `.stock-table-wrap` to allow vertical scrolling within the table container
- Set `max-height: calc(100vh - var(--navbar-h) - 1rem)` on `.stock-table-wrap` to constrain the table height and prevent it from extending beyond the viewport
- Changed sticky header `top` position from `var(--navbar-h)` to `0` to correctly position the header relative to the scrollable container instead of the viewport

## Implementation Details
These changes ensure that:
- The stock table can scroll both horizontally and vertically within its own bounded container
- The table header remains fixed at the top of the scrollable area while the body content scrolls
- The table respects the navbar height and maintains proper spacing from the top of the viewport
- The layout is more compact and user-friendly, especially on smaller screens or with large datasets

https://claude.ai/code/session_017vKkgAkRwTGGiXudN71kDX