### PR TITLE
Fix duplicate material detection to include reference field

### DIFF
--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -193,13 +193,17 @@ async function fetchMaterielChantiersWithFilters(query, { includePhotos = true, 
     normalizedNameExpr = `regexp_replace(upper(unaccent(trim("materiel"."nom"))), '[^A-Z0-9]+', '', 'g')`;
     const chantierIdSql = sequelize.escape(chantierIdInt);
     const duplicateFilterSql = `
-      ${normalizedNameExpr} IN (
+      (
+        regexp_replace(upper(unaccent(trim("materiel"."nom"))), '[^A-Z0-9]+', '', 'g'),
+        coalesce(regexp_replace(upper(unaccent(trim("materiel"."reference"))), '[^A-Z0-9]+', '', 'g'), '')
+      ) IN (
         SELECT
-          regexp_replace(upper(unaccent(trim(m.nom))), '[^A-Z0-9]+', '', 'g') AS nom_norm
+          regexp_replace(upper(unaccent(trim(m.nom))), '[^A-Z0-9]+', '', 'g') AS nom_norm,
+          coalesce(regexp_replace(upper(unaccent(trim(m.reference))), '[^A-Z0-9]+', '', 'g'), '') AS ref_norm
         FROM materiel_chantiers mc
         JOIN materiels m ON m.id = mc."materielId"
         WHERE mc."chantierId" = ${chantierIdSql}
-        GROUP BY nom_norm
+        GROUP BY nom_norm, ref_norm
         HAVING COUNT(*) > 1
       )
     `;


### PR DESCRIPTION
## Summary
Updated the duplicate material detection logic in the chantier routes to consider both the material name and reference fields when identifying duplicates, rather than only the name field.

## Key Changes
- Modified the `duplicateFilterSql` query to check for duplicates based on a tuple of (normalized name, normalized reference) instead of just normalized name
- Updated the subquery to select and group by both `nom_norm` and `ref_norm` fields
- Added normalization of the reference field using the same transformation applied to the name (uppercase, unaccent, trim, remove non-alphanumeric characters)
- Included `coalesce()` to handle null reference values by treating them as empty strings for consistent comparison

## Implementation Details
The duplicate detection now uses a composite key approach where materials are considered duplicates only if they match on both normalized name AND normalized reference. This prevents false positives when different materials happen to have the same name but different references.

https://claude.ai/code/session_01Ef9M43nZeZ2gjZxx1gksJs