### PR TITLE
Enhance voice assistant with Belgian French support and verbal confirmation

### DIFF
--- a/public/js/chantier-voice-assistant/index.js
+++ b/public/js/chantier-voice-assistant/index.js
@@ -127,6 +127,28 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
           }
           logVoice('user input received', transcript);
+
+          // Interception dans l'état preview_ready : confirmation ou annulation verbale
+          const currentState = stateMachine.getState();
+          if (currentState === 'preview_ready' && state.token) {
+            if (isConfirmationPhrase(transcript)) {
+              logVoice('verbal confirmation detected');
+              void confirmCommand();
+              return;
+            }
+            if (isCancellationPhrase(transcript)) {
+              logVoice('verbal cancellation detected');
+              stopInteractiveAudio();
+              resetAssistantState();
+              void speakAssistantMessage('D\'accord, j\'annule. Que voulez-vous faire ?', {
+                afterState: recognitionSupported ? 'awaiting_user_answer' : 'idle',
+                autoListen: recognitionSupported,
+                rememberQuestion: true
+              });
+              return;
+            }
+          }
+
           void analyzeCommand({ transcript, speechConfidence: confidence });
         },
         onError(errorCode) {
@@ -157,6 +179,27 @@ document.addEventListener('DOMContentLoaded', () => {
         (Array.isArray(state.context.candidateIds) && state.context.candidateIds.length > 0)
       )
     );
+  }
+
+  function normalizeTranscriptForIntent(text) {
+    return (text || '')
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .replace(/['']/g, ' ')
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  function isConfirmationPhrase(transcript) {
+    const n = normalizeTranscriptForIntent(transcript);
+    return /\b(?:oui|ok|confirmer|confirme|valider|valide|c est bon|c est ca|d accord|allez|parfait|exactement|je confirme|correct|absolument)\b/.test(n);
+  }
+
+  function isCancellationPhrase(transcript) {
+    const n = normalizeTranscriptForIntent(transcript);
+    return /\b(?:non|annuler|annule|stop|arrete|arreter|recommencer|recommence|quitter|quitte|pas ca|autre chose|changer|change|refaire|reprendre)\b/.test(n);
   }
 
   function setAssistantState(nextState, message = '') {
@@ -341,10 +384,15 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     highlightRow(data.match ? data.match.id : null);
     logVoice('preview ready');
+
+    // Pour la suppression (confirmation forte requise), ne pas auto-écouter : l'utilisateur doit cocher la case
+    const canAutoListen = recognitionSupported && !state.requiresStrongConfirmation;
     await speakAssistantMessage(
-      data.assistantMessage || 'Previsualisation prete.',
+      data.assistantMessage || 'Prévisualisation prête.',
       {
-        afterState: 'preview_ready'
+        afterState: canAutoListen ? 'awaiting_user_answer' : 'preview_ready',
+        autoListen: canAutoListen,
+        rememberQuestion: canAutoListen
       }
     );
   }
@@ -421,8 +469,12 @@ document.addEventListener('DOMContentLoaded', () => {
       ui.setConfirmState({ visible: false });
 
       await speakAssistantMessage(
-        `${data.message} Vous pouvez recommencer ou fermer l assistant.`,
-        { afterState: 'success' }
+        `${data.message} Souhaitez-vous faire autre chose ?`,
+        {
+          afterState: recognitionSupported ? 'awaiting_user_answer' : 'success',
+          autoListen: recognitionSupported,
+          rememberQuestion: true
+        }
       );
     } catch (error) {
       setAssistantState('error', error.message || 'Impossible d executer la commande.');

--- a/public/js/chantier-voice-assistant/speech.js
+++ b/public/js/chantier-voice-assistant/speech.js
@@ -2,13 +2,39 @@ export function isSpeechSynthesisSupported() {
   return Boolean(window.speechSynthesis && window.SpeechSynthesisUtterance);
 }
 
+function selectFrenchVoice(lang) {
+  if (!isSpeechSynthesisSupported()) return null;
+  const voices = window.speechSynthesis.getVoices();
+  if (!voices.length) return null;
+  const frVoices = voices.filter(v => v.lang && v.lang.startsWith('fr'));
+  // Prefer exact match (fr-FR), then local/native voices, then any French
+  const exactMatch = frVoices.filter(v => v.lang === lang);
+  const local = exactMatch.filter(v => v.localService);
+  if (local.length) return local[0];
+  if (exactMatch.length) return exactMatch[0];
+  const localAny = frVoices.filter(v => v.localService);
+  if (localAny.length) return localAny[0];
+  return frVoices.length ? frVoices[0] : null;
+}
+
 export function createSpeechController({
   lang = 'fr-FR',
+  rate = 1.0,
   onStart = () => {},
   onEnd = () => {}
 } = {}) {
   let speaking = false;
   let currentUtterance = null;
+  let selectedVoice = null;
+
+  // Voices may not be loaded immediately — load them once they're ready
+  if (isSpeechSynthesisSupported()) {
+    const trySelectVoice = () => {
+      selectedVoice = selectFrenchVoice(lang);
+    };
+    trySelectVoice();
+    window.speechSynthesis.addEventListener('voiceschanged', trySelectVoice);
+  }
 
   function markEnded(text) {
     speaking = false;
@@ -31,6 +57,10 @@ export function createSpeechController({
         const utterance = new window.SpeechSynthesisUtterance(text);
         currentUtterance = utterance;
         utterance.lang = lang;
+        utterance.rate = rate;
+        if (selectedVoice) {
+          utterance.voice = selectedVoice;
+        }
         utterance.onstart = () => {
           speaking = true;
           console.info('[voice] speech started');

--- a/services/chantierVoice/conversation.js
+++ b/services/chantierVoice/conversation.js
@@ -61,10 +61,10 @@ function buildQuestionStepFromInterpretation(interpretation) {
 
   if (interpretation.intent === 'receptionner' && !interpretation.fields.quantiteReceptionnee) {
     return {
-      assistantMessage: 'Combien ?',
+      assistantMessage: 'Quelle quantité souhaitez-vous réceptionner ?',
       question: {
         type: 'quantite_reception',
-        prompt: 'Combien ?',
+        prompt: 'Quelle quantité souhaitez-vous réceptionner ?',
         expected: 'number'
       }
     };
@@ -77,10 +77,10 @@ function buildQuestionStepFromInterpretation(interpretation) {
   const field = interpretation.fields.field;
   if (!field) {
     return {
-      assistantMessage: 'Quel champ voulez-vous modifier ? Quantite actuelle, quantite recue, remarque ou commentaire ?',
+      assistantMessage: 'Quel champ souhaitez-vous modifier ? La quantité actuelle, la quantité reçue, la remarque ou le commentaire ?',
       question: {
         type: 'modify_field',
-        prompt: 'Quel champ voulez-vous modifier ? Quantite actuelle, quantite recue, remarque ou commentaire ?',
+        prompt: 'Quel champ souhaitez-vous modifier ? La quantité actuelle, la quantité reçue, la remarque ou le commentaire ?',
         expected: 'field'
       }
     };
@@ -99,11 +99,12 @@ function buildQuestionStepFromInterpretation(interpretation) {
     return null;
   }
 
+  const fieldLabel = meta ? meta.label : 'ce champ';
   return {
-    assistantMessage: `Quelle valeur pour ${meta ? meta.label : 'ce champ'} ?`,
+    assistantMessage: `Quelle est la nouvelle valeur pour ${fieldLabel} ?`,
     question: {
       type: 'modify_value',
-      prompt: `Quelle valeur pour ${meta ? meta.label : 'ce champ'} ?`,
+      prompt: `Quelle est la nouvelle valeur pour ${fieldLabel} ?`,
       expected: meta ? meta.expected : 'text',
       field
     }
@@ -125,7 +126,7 @@ function applyPendingQuestionAnswer({ interpretation, pendingQuestion, transcrip
     return {
       answered: false,
       interpretation: nextInterpretation,
-      message: pendingQuestion.prompt || 'Je n ai pas entendu votre reponse.'
+      message: pendingQuestion.prompt || 'Je n\'ai pas entendu votre réponse, pouvez-vous répéter ?'
     };
   }
 
@@ -135,7 +136,7 @@ function applyPendingQuestionAnswer({ interpretation, pendingQuestion, transcrip
       return {
         answered: false,
         interpretation: nextInterpretation,
-        message: 'Je n ai pas compris la quantite. Dites simplement un nombre, par exemple 3.'
+        message: 'Je n\'ai pas compris la quantité. Dites simplement un nombre, par exemple « cinq » ou « 12 ».'
       };
     }
 
@@ -152,7 +153,7 @@ function applyPendingQuestionAnswer({ interpretation, pendingQuestion, transcrip
       return {
         answered: false,
         interpretation: nextInterpretation,
-        message: 'Je n ai pas compris le champ. Dites quantite actuelle, quantite recue, remarque ou commentaire.'
+        message: 'Je n\'ai pas reconnu ce champ. Dites : quantité actuelle, quantité reçue, remarque ou commentaire.'
       };
     }
 
@@ -169,7 +170,7 @@ function applyPendingQuestionAnswer({ interpretation, pendingQuestion, transcrip
       return {
         answered: false,
         interpretation: nextInterpretation,
-        message: 'Je ne sais plus quel champ modifier. Recommencez la commande.'
+        message: 'Je ne sais plus quel champ modifier. Veuillez recommencer la commande.'
       };
     }
 
@@ -180,7 +181,7 @@ function applyPendingQuestionAnswer({ interpretation, pendingQuestion, transcrip
         return {
           answered: false,
           interpretation: nextInterpretation,
-          message: 'Je n ai pas compris la valeur. Dites simplement un nombre.'
+          message: 'Je n\'ai pas compris la valeur. Dites simplement un nombre, par exemple « dix » ou « 25 ».'
         };
       }
 
@@ -205,7 +206,7 @@ function applyPendingQuestionAnswer({ interpretation, pendingQuestion, transcrip
   return {
     answered: false,
     interpretation: nextInterpretation,
-    message: pendingQuestion.prompt || 'Je n ai pas compris votre reponse.'
+    message: pendingQuestion.prompt || 'Je n\'ai pas compris votre réponse, pouvez-vous reformuler ?'
   };
 }
 

--- a/services/chantierVoice/matcher.js
+++ b/services/chantierVoice/matcher.js
@@ -161,8 +161,8 @@ function matchVoiceTarget({
 
   if (!targetQuery && !chantierTokens.length) {
     return {
-      status: 'clarify',
-      message: 'Je n’ai pas identifié le matériel ou la ligne à cibler.'
+      status: ‘clarify’,
+      message: ‘Je n\’ai pas identifié le matériel concerné. Pouvez-vous préciser le nom du matériel ou le chantier ?’
     };
   }
 
@@ -177,7 +177,7 @@ function matchVoiceTarget({
   if (!scoredCandidates.length) {
     return {
       status: 'clarify',
-      message: 'Aucune ligne correspondante trouvée. Reformulez en précisant le matériel ou le chantier.'
+      message: 'Aucune ligne correspondante trouvée. Essayez en précisant davantage le nom du matériel ou le chantier concerné.'
     };
   }
 
@@ -187,8 +187,8 @@ function matchVoiceTarget({
 
   if (needsDisambiguation) {
     return {
-      status: 'clarify',
-      message: `J’ai trouvé ${topMatches.length} résultat${topMatches.length > 1 ? 's' : ''}. Sélectionnez explicitement la bonne ligne ou précisez le chantier.`,
+      status: ‘clarify’,
+      message: `J’ai trouvé ${topMatches.length} lignes correspondantes. Laquelle souhaitez-vous ? Cliquez sur la bonne ligne dans la liste ci-dessous.`,
       matches: topMatches.map(item => buildMatchResult(item.candidate, item.score)),
       candidateIds: topMatches.map(item => item.candidate.id)
     };

--- a/services/chantierVoice/parser.js
+++ b/services/chantierVoice/parser.js
@@ -88,27 +88,37 @@ function extractModifyPayload(rawTranscript, normalizedTranscript) {
 }
 
 function detectIntent(normalizedTranscript) {
-  if (/\b(?:dupliquer|duplique|copie|clone)\b/.test(normalizedTranscript)) {
+  // Confirmation verbale (oui, ok, confirmer …)
+  if (/\b(?:oui|ok|confirmer|confirme|valider|valide|c est bon|c est ca|d accord|allez|parfait|exactement|je confirme|correct|absolument)\b/.test(normalizedTranscript)) {
+    return { intent: 'confirmer', confidence: 0.95 };
+  }
+
+  // Annulation verbale (non, annuler, stop …)
+  if (/\b(?:non|annuler|annule|stop|arrete|arreter|recommencer|recommence|quitter|quitte|pas ca|autre chose|changer|change|refaire|reprendre)\b/.test(normalizedTranscript)) {
+    return { intent: 'annuler', confidence: 0.95 };
+  }
+
+  if (/\b(?:dupliquer|duplique|copier|copie|clone|cloner)\b/.test(normalizedTranscript)) {
     return { intent: 'dupliquer', confidence: 0.88 };
   }
 
-  if (/\b(?:supprimer|supprime|efface|retire|enleve)\b/.test(normalizedTranscript)) {
+  if (/\b(?:supprimer|supprime|efface|effacer|retire|retirer|enleve|enlever|supprression|suppression|delete)\b/.test(normalizedTranscript)) {
     return { intent: 'supprimer', confidence: 0.92 };
   }
 
-  if (/\b(?:receptionner|receptionne|recevoir|recois|recoit|livraison recue|livrer)\b/.test(normalizedTranscript)) {
+  if (/\b(?:receptionner|receptionne|recevoir|recois|recoit|livraison recue|livrer|livre|livraison|j ai recu|ai recu|on a recu|a ete livre|livres|recus|on a livr|vient d arriver|vient d etre livre)\b/.test(normalizedTranscript)) {
     return { intent: 'receptionner', confidence: 0.9 };
   }
 
-  if (/\b(?:modifier|modifie|change|ajuste|mets a jour|met a jour|actualise)\b/.test(normalizedTranscript)) {
+  if (/\b(?:modifier|modifie|change|changer|ajuste|ajuster|mets a jour|met a jour|mettre a jour|actualise|actualiser|corriger|corrige|editer|edite|update|mise a jour)\b/.test(normalizedTranscript)) {
     return { intent: 'modifier', confidence: 0.8 };
   }
 
-  if (/\b(?:ouvrir|ouvre|fiche)\b/.test(normalizedTranscript)) {
+  if (/\b(?:ouvrir|ouvre|fiche|consulter|consulte|afficher|affiche|voir|montre|montrer|naviguer|navigate)\b/.test(normalizedTranscript)) {
     return { intent: 'ouvrir', confidence: 0.84 };
   }
 
-  if (/\b(?:info|infos|information|informations|detail|details|montre|affiche|voir)\b/.test(normalizedTranscript)) {
+  if (/\b(?:info|infos|information|informations|detail|details|renseignement|renseignements)\b/.test(normalizedTranscript)) {
     return { intent: 'info', confidence: 0.72 };
   }
 
@@ -188,6 +198,12 @@ function parseVoiceTranscript(transcript, { speechConfidence = null } = {}) {
         .replace(/\b(?:supprimer|supprime|efface|retire|enleve)\b/g, ' ')
     );
     result.fields.requiresStrongConfirmation = true;
+  }
+
+  // Pour confirmer/annuler, pas besoin de targetText ni de needsConfirmation supplémentaire
+  if (result.intent === 'confirmer' || result.intent === 'annuler') {
+    result.needsConfirmation = false;
+    result.targetText = '';
   }
 
   if (result.speechConfidence != null && result.speechConfidence < 0.65) {

--- a/services/chantierVoice/preview.js
+++ b/services/chantierVoice/preview.js
@@ -55,7 +55,7 @@ function buildPreviewFromMatch({ interpretation, candidate }) {
     });
 
     return {
-      assistantMessage: `Prévisualisation prête pour la réception de ${quantity} unité${quantity > 1 ? 's' : ''}.`,
+      assistantMessage: `J'ai préparé la réception de ${quantity} unité${quantity > 1 ? 's' : ''}. Dites « oui » pour confirmer ou « non » pour annuler.`,
       confirmationLabel: 'Confirmer la réception',
       requiresStrongConfirmation: false,
       preview: {
@@ -91,7 +91,7 @@ function buildPreviewFromMatch({ interpretation, candidate }) {
     const preview = buildQuickEditPreview(candidate.raw, field, value);
 
     return {
-      assistantMessage: 'Prévisualisation prête pour la modification demandée.',
+      assistantMessage: 'Modification prête. Dites « oui » pour confirmer ou « non » pour annuler.',
       confirmationLabel: 'Confirmer la modification',
       requiresStrongConfirmation: false,
       preview: {
@@ -118,7 +118,7 @@ function buildPreviewFromMatch({ interpretation, candidate }) {
 
   if (interpretation.intent === 'dupliquer') {
     return {
-      assistantMessage: 'Prévisualisation prête pour la duplication.',
+      assistantMessage: 'Duplication prête. Dites « oui » pour confirmer ou « non » pour annuler.',
       confirmationLabel: 'Confirmer la duplication',
       requiresStrongConfirmation: false,
       preview: {
@@ -143,7 +143,7 @@ function buildPreviewFromMatch({ interpretation, candidate }) {
 
   if (interpretation.intent === 'supprimer') {
     return {
-      assistantMessage: 'Prévisualisation prête. Vérifiez bien avant de supprimer.',
+      assistantMessage: 'Attention, cette action est irréversible. Cochez la case de confirmation pour supprimer.',
       confirmationLabel: 'Confirmer la suppression',
       requiresStrongConfirmation: true,
       preview: {
@@ -168,7 +168,7 @@ function buildPreviewFromMatch({ interpretation, candidate }) {
 
   if (interpretation.intent === 'ouvrir' || interpretation.intent === 'info') {
     return {
-      assistantMessage: 'La fiche est prête à être ouverte.',
+      assistantMessage: 'Voici la fiche trouvée. Dites « oui » pour l\'ouvrir.',
       confirmationLabel: interpretation.intent === 'ouvrir' ? 'Ouvrir la fiche' : 'Voir les infos',
       requiresStrongConfirmation: false,
       preview: {

--- a/services/chantierVoice/utils.js
+++ b/services/chantierVoice/utils.js
@@ -43,7 +43,10 @@ const SPOKEN_NUMBER_TENS = {
   trente: 30,
   quarante: 40,
   cinquante: 50,
-  soixante: 60
+  soixante: 60,
+  septante: 70,
+  huitante: 80,
+  nonante: 90
 };
 
 const STOP_WORDS = new Set([
@@ -106,40 +109,96 @@ function parseFrenchSpokenNumber(value) {
     return toInt(normalized);
   }
 
-  const tokens = normalized.split(' ').filter(Boolean);
+  // Remove 'et' connector (vingt et un → vingt un) to simplify pattern matching
+  const tokens = normalized.split(' ').filter(t => t && t !== 'et');
   if (!tokens.length) {
     return null;
   }
 
+  function isUnit(t) {
+    return Object.prototype.hasOwnProperty.call(SPOKEN_NUMBER_UNITS, t);
+  }
+  function isTens(t) {
+    return Object.prototype.hasOwnProperty.call(SPOKEN_NUMBER_TENS, t);
+  }
+
+  // Single token: 0-16, tens (20-90), cent, mille
   if (tokens.length === 1) {
-    if (Object.prototype.hasOwnProperty.call(SPOKEN_NUMBER_UNITS, tokens[0])) {
-      return SPOKEN_NUMBER_UNITS[tokens[0]];
+    const t = tokens[0];
+    if (isUnit(t)) return SPOKEN_NUMBER_UNITS[t];
+    if (isTens(t)) return SPOKEN_NUMBER_TENS[t];
+    if (t === 'cent') return 100;
+    if (t === 'mille') return 1000;
+    return null;
+  }
+
+  // Two tokens
+  if (tokens.length === 2) {
+    // quatre-vingts (80)
+    if (tokens[0] === 'quatre' && (tokens[1] === 'vingt' || tokens[1] === 'vingts')) return 80;
+    // dix-sept / dix-huit / dix-neuf (17-19)
+    if (tokens[0] === 'dix' && isUnit(tokens[1])) return 10 + SPOKEN_NUMBER_UNITS[tokens[1]];
+    // tens + unit: vingt-deux (22), soixante-dix (70) …
+    if (isTens(tokens[0]) && isUnit(tokens[1])) return SPOKEN_NUMBER_TENS[tokens[0]] + SPOKEN_NUMBER_UNITS[tokens[1]];
+    // cent + unit (101-116) or cent + tens (120-190)
+    if (tokens[0] === 'cent') {
+      if (isUnit(tokens[1])) return 100 + SPOKEN_NUMBER_UNITS[tokens[1]];
+      if (isTens(tokens[1])) return 100 + SPOKEN_NUMBER_TENS[tokens[1]];
     }
-    if (Object.prototype.hasOwnProperty.call(SPOKEN_NUMBER_TENS, tokens[0])) {
-      return SPOKEN_NUMBER_TENS[tokens[0]];
+    // X cent(s) (200, 300 … 900)
+    if ((tokens[1] === 'cent' || tokens[1] === 'cents') && isUnit(tokens[0])) {
+      return SPOKEN_NUMBER_UNITS[tokens[0]] * 100;
     }
     return null;
   }
 
-  if (tokens[0] === 'dix' && tokens.length === 2 && Object.prototype.hasOwnProperty.call(SPOKEN_NUMBER_UNITS, tokens[1])) {
-    return 10 + SPOKEN_NUMBER_UNITS[tokens[1]];
-  }
-
-  if (!Object.prototype.hasOwnProperty.call(SPOKEN_NUMBER_TENS, tokens[0])) {
+  // Three tokens
+  if (tokens.length === 3) {
+    // quatre-vingt-X (81-89) and quatre-vingt-dix (90)
+    if (tokens[0] === 'quatre' && (tokens[1] === 'vingt' || tokens[1] === 'vingts')) {
+      if (tokens[2] === 'dix') return 90;
+      if (isUnit(tokens[2])) return 80 + SPOKEN_NUMBER_UNITS[tokens[2]];
+      return null;
+    }
+    // soixante-dix-sept / huit / neuf (77-79)
+    if (tokens[0] === 'soixante' && tokens[1] === 'dix' && isUnit(tokens[2])) {
+      return 70 + SPOKEN_NUMBER_UNITS[tokens[2]];
+    }
+    // cent + tens + unit (cent vingt trois = 123)
+    if (tokens[0] === 'cent' && isTens(tokens[1]) && isUnit(tokens[2])) {
+      return 100 + SPOKEN_NUMBER_TENS[tokens[1]] + SPOKEN_NUMBER_UNITS[tokens[2]];
+    }
+    // X cent(s) + unit or tens (deux cent cinq = 205, deux cent vingt = 220)
+    if ((tokens[1] === 'cent' || tokens[1] === 'cents') && isUnit(tokens[0])) {
+      const base = SPOKEN_NUMBER_UNITS[tokens[0]] * 100;
+      if (isUnit(tokens[2])) return base + SPOKEN_NUMBER_UNITS[tokens[2]];
+      if (isTens(tokens[2])) return base + SPOKEN_NUMBER_TENS[tokens[2]];
+      return null;
+    }
     return null;
   }
 
-  const base = SPOKEN_NUMBER_TENS[tokens[0]];
-  if (tokens.length === 2 && Object.prototype.hasOwnProperty.call(SPOKEN_NUMBER_UNITS, tokens[1])) {
-    return base + SPOKEN_NUMBER_UNITS[tokens[1]];
-  }
-
-  if (
-    tokens.length === 3 &&
-    tokens[1] === 'et' &&
-    Object.prototype.hasOwnProperty.call(SPOKEN_NUMBER_UNITS, tokens[2])
-  ) {
-    return base + SPOKEN_NUMBER_UNITS[tokens[2]];
+  // Four tokens
+  if (tokens.length === 4) {
+    // quatre-vingt-dix-X (91-99)
+    if (
+      tokens[0] === 'quatre' &&
+      (tokens[1] === 'vingt' || tokens[1] === 'vingts') &&
+      tokens[2] === 'dix' &&
+      isUnit(tokens[3])
+    ) {
+      return 90 + SPOKEN_NUMBER_UNITS[tokens[3]];
+    }
+    // X cent(s) + tens + unit (deux cent vingt trois = 223)
+    if (
+      (tokens[1] === 'cent' || tokens[1] === 'cents') &&
+      isUnit(tokens[0]) &&
+      isTens(tokens[2]) &&
+      isUnit(tokens[3])
+    ) {
+      return SPOKEN_NUMBER_UNITS[tokens[0]] * 100 + SPOKEN_NUMBER_TENS[tokens[2]] + SPOKEN_NUMBER_UNITS[tokens[3]];
+    }
+    return null;
   }
 
   return null;


### PR DESCRIPTION
## Summary
This PR significantly improves the voice assistant's language support and user interaction flow by adding Belgian French number variants, implementing verbal confirmation/cancellation phrases, and enhancing the conversation experience with better prompts and voice synthesis.

## Key Changes

### Language & Number Parsing
- Added support for Belgian French number words: `septante` (70), `huitante` (80), `nonante` (90) in `SPOKEN_NUMBER_TENS`
- Completely refactored `parseFrenchSpokenNumber()` to handle complex number patterns more robustly:
  - Improved handling of compound numbers (quatre-vingts, soixante-dix, etc.)
  - Better support for hundreds (cent, cents) with units and tens
  - Cleaner token-based parsing with dedicated helper functions (`isUnit()`, `isTens()`)
  - Removed 'et' connector preprocessing for simplified pattern matching

### Verbal Confirmation & Cancellation
- Added `isConfirmationPhrase()` and `isCancellationPhrase()` functions to detect user intent from speech
- Implemented interception logic in `preview_ready` state to allow users to confirm/cancel via voice commands
- Added confirmation/cancellation intent detection in `parser.js` with high confidence (0.95)
- Users can now say "oui", "ok", "confirmer", "non", "annuler", "stop", etc. to control the assistant

### Voice Synthesis Improvements
- Enhanced `createSpeechController()` with:
  - French voice selection logic (`selectFrenchVoice()`) with preference for local/native voices
  - Configurable speech rate parameter
  - Dynamic voice loading via `voiceschanged` event listener
  - Proper voice assignment to utterances

### Conversation & UX Enhancements
- Improved assistant messages throughout the conversation flow:
  - More natural and contextual prompts (e.g., "Quelle quantité souhaitez-vous réceptionner ?" instead of "Combien ?")
  - Better error messages with actionable guidance
  - Added voice command hints in preview messages ("Dites « oui » pour confirmer ou « non » pour annuler")
- Enhanced intent detection with more keyword variations:
  - Duplicate: added "copier", "cloner"
  - Delete: added "effacer", "retirer", "enlever", "suppression"
  - Receive: added "livraison", "j ai recu", "vient d arriver"
  - Modify: added "changer", "ajuster", "corriger", "update"
  - Open: added "consulter", "afficher", "montrer", "naviguer"

### State Management
- Modified preview state to auto-listen for confirmation only when not requiring strong confirmation (e.g., skip auto-listen for deletions)
- Updated success state to offer continued interaction ("Souhaitez-vous faire autre chose ?") instead of just closing
- Improved state transitions to keep conversation flowing naturally

### Message Quality
- Fixed French grammar and accents throughout (e.g., "Prévisualisation" → "Prévisualisation", "n ai" → "n\'ai")
- More conversational and user-friendly error messages
- Better formatting of assistant prompts with proper punctuation

## Implementation Details
- The number parsing refactor uses a token-based approach that's more maintainable and extensible
- Voice selection prioritizes: exact language match → local service → any French voice
- Confirmation/cancellation detection uses normalized transcripts (NFD normalization, accent removal, lowercase)
- Strong confirmation flag prevents auto-listening for destructive operations (deletion)

https://claude.ai/code/session_01F4WDhZieJ5FTu4iMcB5MLX