### PR TITLE
Improve voice matching with chantier filtering and better disambiguation

### DIFF
--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -1248,7 +1248,8 @@ router.post('/voice/preview', ensureAuthenticated, async (req, res) => {
       interpretation,
       selectedTargetId,
       candidateIds,
-      clarificationText: usePreviousInterpretation ? transcript : ''
+      clarificationText: usePreviousInterpretation ? transcript : '',
+      filters
     });
 
     if (matchResult.status !== 'matched') {

--- a/services/chantierVoice/matcher.js
+++ b/services/chantierVoice/matcher.js
@@ -126,8 +126,10 @@ function matchVoiceTarget({
   interpretation,
   selectedTargetId = null,
   candidateIds = [],
-  clarificationText = ''
+  clarificationText = ‘’,
+  filters = {}
 }) {
+  const chantierFiltered = Boolean(filters && filters.chantierId);
   const serializedCandidates = rows.map(serializeCandidate);
   const candidateIdSet = Array.isArray(candidateIds) && candidateIds.length
     ? new Set(candidateIds.map(value => String(value)))
@@ -141,13 +143,13 @@ function matchVoiceTarget({
     const selected = availableCandidates.find(candidate => String(candidate.id) === String(selectedTargetId));
     if (!selected) {
       return {
-        status: 'error',
-        message: 'La ligne choisie n’est plus disponible.'
+        status: ‘error’,
+        message: ‘La ligne choisie n’est plus disponible.’
       };
     }
 
     return {
-      status: 'matched',
+      status: ‘matched’,
       selected,
       matches: [buildMatchResult(selected, 999)]
     };
@@ -160,9 +162,12 @@ function matchVoiceTarget({
   const chantierTokens = tokenize(interpretation.chantierText);
 
   if (!targetQuery && !chantierTokens.length) {
+    const clarifyMsg = chantierFiltered
+      ? ‘Je n\’ai pas identifié le matériel concerné. Pouvez-vous préciser le nom du matériel ?’
+      : ‘Je n\’ai pas identifié le matériel concerné. Pouvez-vous préciser le nom du matériel ou le chantier ?’;
     return {
-      status: 'clarify',
-      message: 'Je n\'ai pas identifié le matériel concerné. Pouvez-vous préciser le nom du matériel ou le chantier ?'
+      status: ‘clarify’,
+      message: clarifyMsg
     };
   }
 
@@ -175,19 +180,29 @@ function matchVoiceTarget({
     .sort((left, right) => right.score - left.score);
 
   if (!scoredCandidates.length) {
+    const noMatchMsg = chantierFiltered
+      ? ‘Aucune ligne correspondante trouvée. Essayez en précisant davantage le nom du matériel.’
+      : ‘Aucune ligne correspondante trouvée. Essayez en précisant davantage le nom du matériel ou le chantier concerné.’;
     return {
-      status: 'clarify',
-      message: 'Aucune ligne correspondante trouvée. Essayez en précisant davantage le nom du matériel ou le chantier concerné.'
+      status: ‘clarify’,
+      message: noMatchMsg
     };
   }
 
   const best = scoredCandidates[0];
   const topMatches = scoredCandidates.slice(0, 5);
-  const needsDisambiguation = topMatches.length > 1;
+  const secondScore = scoredCandidates.length > 1 ? scoredCandidates[1].score : 0;
 
-  if (needsDisambiguation) {
+  // Auto-select when there is a single candidate, or when the best score
+  // clearly dominates (at least twice the second-best score), avoiding
+  // unnecessary disambiguation when a name matches precisely.
+  const isClearMatch =
+    scoredCandidates.length === 1 ||
+    (best.score > secondScore && best.score >= secondScore * 2);
+
+  if (!isClearMatch) {
     return {
-      status: 'clarify',
+      status: ‘clarify’,
       message: `J’ai trouvé ${topMatches.length} lignes correspondantes. Laquelle souhaitez-vous ? Cliquez sur la bonne ligne dans la liste ci-dessous.`,
       matches: topMatches.map(item => buildMatchResult(item.candidate, item.score)),
       candidateIds: topMatches.map(item => item.candidate.id)
@@ -195,7 +210,7 @@ function matchVoiceTarget({
   }
 
   return {
-    status: 'matched',
+    status: ‘matched’,
     selected: best.candidate,
     matches: topMatches.map(item => buildMatchResult(item.candidate, item.score))
   };


### PR DESCRIPTION
## Summary
Enhanced the voice matching system to support chantier (worksite) filtering and improved the auto-selection logic to reduce unnecessary disambiguation prompts when a clear match is found.

## Key Changes
- **Added chantier filtering support**: The `matchVoiceTarget` function now accepts a `filters` parameter to detect when a specific chantier is already selected, allowing for more contextual clarification messages
- **Improved disambiguation logic**: Replaced simple multi-candidate check with a scoring-based approach that auto-selects when:
  - Only one candidate exists, or
  - The best match score is at least twice the second-best score (indicating a clear winner)
- **Context-aware messages**: Clarification prompts now adapt based on whether a chantier filter is active:
  - When filtered: Asks only for material name clarification
  - When unfiltered: Asks for both material name and chantier clarification
- **Updated voice preview route**: Passes the `filters` parameter from the request to the matching function

## Implementation Details
- The `chantierFiltered` flag is computed early to determine message variants throughout the function
- The new disambiguation threshold (2x score multiplier) prevents unnecessary user prompts when one option clearly dominates, improving user experience
- All clarification messages are now dynamically constructed based on filter context rather than using static strings

https://claude.ai/code/session_01LMhitKeB7e87yr7GQfZjD7