### PR TITLE
Fix clarification text logic in voice preview endpoint

### DIFF
--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -1248,7 +1248,7 @@ router.post('/voice/preview', ensureAuthenticated, async (req, res) => {
       interpretation,
       selectedTargetId,
       candidateIds,
-      clarificationText: usePreviousInterpretation ? transcript : '',
+      clarificationText: (usePreviousInterpretation && !pendingQuestion) ? transcript : '',
       filters
     });
 


### PR DESCRIPTION
## Summary
Fixed the condition for setting clarification text in the voice preview endpoint to prevent it from being populated when a pending question exists.

## Key Changes
- Modified the `clarificationText` assignment logic in the `/voice/preview` POST endpoint to include an additional check for `!pendingQuestion`
- Changed from: `clarificationText: usePreviousInterpretation ? transcript : ''`
- Changed to: `clarificationText: (usePreviousInterpretation && !pendingQuestion) ? transcript : ''`

## Implementation Details
This ensures that the clarification text is only set when both conditions are met:
1. The user intends to use the previous interpretation (`usePreviousInterpretation` is true)
2. There is no pending question (`pendingQuestion` is false)

This prevents conflicting states where clarification text would be populated while a pending question is awaiting response.

https://claude.ai/code/session_01R2aEyBvTBbiqdTkuYHM8ZN