### PR TITLE
Improve voice assistant interpretation logic and confirmation handling

### DIFF
--- a/public/js/chantier-voice-assistant/index.js
+++ b/public/js/chantier-voice-assistant/index.js
@@ -128,9 +128,10 @@ document.addEventListener('DOMContentLoaded', () => {
           }
           logVoice('user input received', transcript);
 
-          // Interception dans l'état preview_ready : confirmation ou annulation verbale
+          // Interception dans preview_ready ou awaiting_user_answer (après lecture auto)
+          // quand un token de prévisualisation est présent : confirmation ou annulation verbale
           const currentState = stateMachine.getState();
-          if (currentState === 'preview_ready' && state.token) {
+          if (state.token && (currentState === 'preview_ready' || currentState === 'awaiting_user_answer')) {
             if (isConfirmationPhrase(transcript)) {
               logVoice('verbal confirmation detected');
               void confirmCommand();

--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -1178,13 +1178,14 @@ router.post('/voice/preview', ensureAuthenticated, async (req, res) => {
     });
     req.session.chantierVoicePreview = null;
 
+    const userInputIsUnclear = parsedInterpretation.intent === 'inconnue' || parsedInterpretation.confidence < 0.45;
     const usePreviousInterpretation = previousInterpretation && (
       pendingQuestion ||
       selectedTargetId ||
-      (candidateIds.length > 0 && (
-        parsedInterpretation.intent === 'inconnue' ||
-        parsedInterpretation.confidence < 0.45
-      ))
+      (candidateIds.length > 0 && userInputIsUnclear) ||
+      // L'utilisateur précise le matériel (ex: "applique murale" après "receptionner")
+      // sans candidats connus mais avec une intention précédente claire
+      (previousInterpretation.intent !== 'inconnue' && userInputIsUnclear)
     );
 
     let interpretation = usePreviousInterpretation


### PR DESCRIPTION
## Summary
This PR enhances the voice assistant's interpretation logic to better handle user clarifications and expands the confirmation phrase detection to work in additional states.

## Key Changes

- **Refactored interpretation reuse logic** (`routes/chantier.js`):
  - Extracted the "unclear input" condition into a reusable variable (`userInputIsUnclear`) for better readability
  - Added support for a new scenario: when the user clarifies/specifies equipment (e.g., "wall sconce" after "receive") without known candidates, the system now reuses the previous interpretation if it was clear
  - This allows the assistant to maintain context when users provide additional details about items in a multi-step workflow

- **Extended verbal confirmation detection** (`public/js/chantier-voice-assistant/index.js`):
  - Expanded confirmation phrase interception to work in both `preview_ready` and `awaiting_user_answer` states (previously only `preview_ready`)
  - Updated condition to check for preview token presence first, making the logic more explicit
  - This enables users to confirm commands verbally even after the system has automatically read back a preview

## Implementation Details
The changes maintain backward compatibility while improving the user experience in voice-driven workflows by allowing more natural interaction patterns where users can clarify their intent or confirm actions at multiple points in the conversation flow.

https://claude.ai/code/session_01RgAFpji48AcyQL7NjNofDx