### PR TITLE
Add bulk delete functionality for equipment items

### DIFF
--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -2247,6 +2247,24 @@ router.post('/materielChantier/supprimer/:id', ensureAuthenticated, checkAdmin, 
   }
 });
 
+// Suppression en masse de MaterielChantier
+router.post('/materielChantier/supprimer-masse', ensureAuthenticated, checkAdmin, async (req, res) => {
+  try {
+    const { ids } = req.body;
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return res.status(400).json({ error: 'Aucun identifiant fourni.' });
+    }
+    const userId = req.user ? req.user.id : null;
+    const results = await Promise.all(
+      ids.map(id => executeDelete({ mcId: id, userId, source: 'manual' }))
+    );
+    return res.json({ deleted: results.length });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: "Erreur lors de la suppression en masse." });
+  }
+});
+
 router.get('/materielChantier/dupliquer/:id', ensureAuthenticated, checkAdmin, async (req, res) => {
   const mc = await MaterielChantier.findByPk(req.params.id, {
     include: [

--- a/views/chantier/index.ejs
+++ b/views/chantier/index.ejs
@@ -1870,6 +1870,14 @@
         >
           Mettre à jour l'alerte
         </button>
+        <button
+          type="button"
+          class="btn btn-danger"
+          id="openBulkDelete"
+          disabled
+        >
+          Supprimer la sélection
+        </button>
       </div>
     <% } %>
 
@@ -2807,6 +2815,25 @@
             <button type="submit" class="btn btn-danger">Supprimer</button>
           </div>
         </form>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal fade" id="bulkDeleteModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header bg-danger text-white">
+          <h5 class="modal-title">Confirmer la suppression en masse</h5>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+        </div>
+        <div class="modal-body">
+          <p>Vous êtes sur le point de supprimer <strong id="bulkDeleteCount"></strong> du chantier.</p>
+          <p class="mb-0"><em>Cette action est irréversible.</em></p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+          <button type="button" class="btn btn-danger" id="confirmBulkDelete">Supprimer</button>
+        </div>
       </div>
     </div>
   </div>
@@ -5327,6 +5354,9 @@ FOURNISSEUR_CONTACTS["JM EXIM"] = FOURNISSEUR_CONTACTS["JM EXIM MENUISERIE PVC"]
         const alertForm = document.getElementById('alertStatusForm');
         const alertSubmit = document.getElementById('confirmAlertStatus');
         const alertSelectionInfo = document.getElementById('alertSelectionInfo');
+        const bulkDeleteBtn = document.getElementById('openBulkDelete');
+        const confirmBulkDeleteBtn = document.getElementById('confirmBulkDelete');
+        const bulkDeleteCountSpan = document.getElementById('bulkDeleteCount');
 
         const CLOUD_NAME = '<%= cloudinaryCloudName || "" %>';
         const UPLOAD_PRESET = '<%= cloudinaryUploadPresetBdl || "" %>';
@@ -5385,6 +5415,7 @@ FOURNISSEUR_CONTACTS["JM EXIM"] = FOURNISSEUR_CONTACTS["JM EXIM MENUISERIE PVC"]
           if (submitBtn) submitBtn.disabled = !hasSelection;
           if (alertBtn) alertBtn.disabled = !hasLowSelection;
           if (alertSubmit) alertSubmit.disabled = !hasLowSelection;
+          if (bulkDeleteBtn) bulkDeleteBtn.disabled = !hasSelection;
           if (selectAll) {
             selectAll.checked = hasSelection && rowCheckboxes.every(cb => cb.checked);
             selectAll.indeterminate = !selectAll.checked && hasSelection;
@@ -5546,6 +5577,44 @@ FOURNISSEUR_CONTACTS["JM EXIM"] = FOURNISSEUR_CONTACTS["JM EXIM MENUISERIE PVC"]
           alertModal.addEventListener('hidden.bs.modal', () => {
             const selected = alertForm ? alertForm.querySelectorAll('input[name="alertStatusChoice"]') : [];
             selected.forEach(input => { input.checked = false; });
+          });
+        }
+
+        if (bulkDeleteBtn) {
+          bulkDeleteBtn.addEventListener('click', () => {
+            const ids = getSelectedIds();
+            if (!ids.length) return;
+            if (bulkDeleteCountSpan) {
+              bulkDeleteCountSpan.textContent = ids.length === 1
+                ? '1 matériel'
+                : `${ids.length} matériels`;
+            }
+            const modal = new bootstrap.Modal(document.getElementById('bulkDeleteModal'));
+            modal.show();
+          });
+        }
+
+        if (confirmBulkDeleteBtn) {
+          confirmBulkDeleteBtn.addEventListener('click', async () => {
+            const ids = getSelectedIds();
+            if (!ids.length) return;
+            confirmBulkDeleteBtn.disabled = true;
+            try {
+              const resp = await fetch('/chantier/materielChantier/supprimer-masse', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ ids })
+              });
+              if (!resp.ok) {
+                const txt = await resp.text();
+                throw new Error(txt || 'Erreur serveur');
+              }
+              window.location.reload();
+            } catch (err) {
+              console.error('Erreur suppression en masse :', err);
+              alert('Impossible de supprimer les lignes sélectionnées : ' + err.message);
+              confirmBulkDeleteBtn.disabled = false;
+            }
           });
         }
 


### PR DESCRIPTION
## Summary
This PR adds a bulk delete feature that allows users to select multiple equipment items (MaterielChantier) and delete them in a single operation, with a confirmation modal to prevent accidental deletions.

## Key Changes
- **UI Components**: Added a "Supprimer la sélection" (Delete Selection) button in the equipment list toolbar that is enabled only when items are selected
- **Confirmation Modal**: Implemented a new Bootstrap modal (`bulkDeleteModal`) that displays the number of items to be deleted and requires explicit confirmation before proceeding
- **Frontend Logic**: 
  - Button state management that enables/disables the delete button based on selection status
  - Modal display with dynamic item count
  - Async fetch request to the bulk delete endpoint with error handling
  - Page reload on successful deletion
- **Backend Endpoint**: Added new POST route `/materielChantier/supprimer-masse` that:
  - Accepts an array of equipment IDs
  - Validates input (non-empty array required)
  - Executes deletion for each item using the existing `executeDelete` function
  - Tracks user ID and deletion source for audit purposes
  - Returns appropriate error responses for invalid requests or server errors

## Implementation Details
- The bulk delete operation reuses the existing `executeDelete` function to maintain consistency with single-item deletion logic
- User authentication and admin authorization checks are enforced on the backend route
- The frontend gracefully handles network errors and displays user-friendly error messages
- Page reload ensures the UI reflects the deleted items immediately

https://claude.ai/code/session_01N43eTxCKASxb341Sf84amv